### PR TITLE
🐛 fix: Vercelデプロイエラーの修正 - Firebase設定の環境変数対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,14 @@ cd ../web && npm install
 firebase login
 firebase init
 
-# 環境変数設定
+# 環境変数設定（重要）
 cp web/.env.example web/.env.local
-# .env.local を編集
+# .env.local を編集して Firebase の認証情報を設定
+
+# Vercel デプロイ時は以下の環境変数を設定:
+# - NEXT_PUBLIC_FIREBASE_API_KEY
+# - NEXT_PUBLIC_FIREBASE_APP_ID
+# その他の値は .env.example を参照
 ```
 
 ### 4. ローカル開発

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,25 @@
+# Firebase Configuration
+# These environment variables are required for the application to work
+# Copy this file to .env.local and fill in your Firebase project values
+# For production deployment on Vercel, add these as environment variables in your Vercel project settings
+
+# Required: Firebase API Key (Get from Firebase Console > Project Settings)
+NEXT_PUBLIC_FIREBASE_API_KEY=your-api-key-here
+
+# Required: Firebase Auth Domain
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=line-kakeibo-0410.firebaseapp.com
+
+# Required: Firebase Project ID
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=line-kakeibo-0410
+
+# Firebase Storage Bucket
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=line-kakeibo-0410.appspot.com
+
+# Firebase Messaging Sender ID
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=440748785600
+
+# Required: Firebase App ID (Get from Firebase Console > Project Settings)
+NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id-here
+
+# Firebase Measurement ID (for Google Analytics)
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=G-PLNC7GY160

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -7,12 +7,21 @@ import { CategoryPieChart, DailyLineChart } from '../components/Charts';
 import { getDateRangeSettings, getEffectiveDateRange, getDisplayTitle, type DateRangeSettings } from '../lib/dateSettings';
 import Header from '../components/Header';
 import dayjs from 'dayjs';
+import { db } from '../lib/firebase';
 
 export default function Dashboard() {
   const { user, loading: authLoading, getUrlWithLineId } = useLineAuth();
   const [currentDate, setCurrentDate] = useState(dayjs());
   const [dateSettings, setDateSettings] = useState<DateRangeSettings>({ mode: 'monthly' });
   const [settingsLoading, setSettingsLoading] = useState(true);
+  const [firebaseError, setFirebaseError] = useState(false);
+  
+  useEffect(() => {
+    // Check if Firebase is properly initialized
+    if (typeof window !== 'undefined' && !db) {
+      setFirebaseError(true);
+    }
+  }, []);
   
   useEffect(() => {
     const loadSettings = async () => {
@@ -57,6 +66,31 @@ export default function Dashboard() {
       setCurrentDate(prev => prev.add(1, 'month'));
     }
   };
+
+  if (firebaseError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-red-50 via-white to-orange-50">
+        <div className="text-center max-w-md p-8 bg-white rounded-lg shadow-lg">
+          <div className="text-red-500 mb-4">
+            <svg className="w-16 h-16 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">設定エラー</h2>
+          <p className="text-gray-600 mb-6">
+            アプリケーションの初期化に失敗しました。<br />
+            システム管理者にお問い合わせください。
+          </p>
+          <div className="bg-gray-100 rounded-lg p-4 text-left">
+            <p className="text-sm text-gray-600 font-mono">
+              Firebase configuration is missing.<br />
+              Please check environment variables.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (authLoading || settingsLoading) {
     return (

--- a/web/lib/firebase.ts
+++ b/web/lib/firebase.ts
@@ -3,20 +3,41 @@ import { getFirestore } from 'firebase/firestore';
 import { getAuth, signInAnonymously, UserCredential } from 'firebase/auth';
 
 const config = {
-  authDomain: "line-kakeibo-0410.firebaseapp.com",
-  projectId: "line-kakeibo-0410",
-  storageBucket: "line-kakeibo-0410.appspot.com",
-  messagingSenderId: "440748785600",
-  appId: "",
-  measurementId: "G-PLNC7GY160",
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY || "",
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || "line-kakeibo-0410.firebaseapp.com",
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || "line-kakeibo-0410",
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "line-kakeibo-0410.appspot.com",
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || "440748785600",
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID || "",
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID || "G-PLNC7GY160",
 };
 
-const app =
-  typeof window === 'undefined'
+// 必須の設定値をチェック
+const validateConfig = () => {
+  if (typeof window === 'undefined') return true; // SSRでは検証しない
+  
+  const required = ['apiKey', 'authDomain', 'projectId'];
+  const missing = required.filter(key => !config[key as keyof typeof config]);
+  
+  if (missing.length > 0) {
+    console.error(`Firebase configuration error: Missing required fields: ${missing.join(', ')}`);
+    console.error('Please ensure all Firebase environment variables are set in Vercel.');
+    return false;
+  }
+  return true;
+};
+
+let app;
+try {
+  app = typeof window === 'undefined'
     ? undefined
     : getApps().length
       ? getApp()
-      : initializeApp(config);
+      : validateConfig() ? initializeApp(config) : undefined;
+} catch (error) {
+  console.error('Failed to initialize Firebase:', error);
+  app = undefined;
+}
 
 export const db   = app ? getFirestore(app) : undefined;
 export const auth = app ? getAuth(app)       : undefined;


### PR DESCRIPTION
## 概要
Vercelでアプリケーションを開くと「Application error: a client-side exception has occurred」というエラーが発生していた問題を修正しました。

## 問題の原因
Firebase設定に必要な**API Key**と**App ID**が設定されていなかったため、Firebaseの初期化に失敗していました。

## 変更内容
### 1. Firebase設定を環境変数から取得するように変更
- `web/lib/firebase.ts`でFirebase設定を環境変数から読み込むように修正
- 必須フィールド（apiKey, authDomain, projectId）のバリデーションを追加

### 2. エラーハンドリングの改善
- Firebaseの初期化が失敗した場合にユーザーフレンドリーなエラー画面を表示
- エラーメッセージで設定の問題であることを明示

### 3. 環境変数のドキュメント化
- `.env.example`ファイルを追加して必要な環境変数を明示
- READMEにVercelデプロイ時の環境変数設定について追記

## 対応方法
### Vercelでの設定
1. Vercelのプロジェクト設定ページにアクセス
2. Environment Variablesセクションで以下を追加：
   - `NEXT_PUBLIC_FIREBASE_API_KEY`: Firebase ConsoleのProject Settingsから取得
   - `NEXT_PUBLIC_FIREBASE_APP_ID`: Firebase ConsoleのProject Settingsから取得
3. デプロイを再実行

## テスト結果
- [x] コードの文法エラーがないことを確認
- [x] Firebaseの初期化エラー時にエラー画面が表示されることを確認
- [ ] Vercelに環境変数を設定後、正常に動作することを確認（要対応）

## 関連Issue
LINE家計簿アプリのVercelデプロイエラー対応