### PR TITLE
Web: カテゴリの統一とプルダウン更新

### DIFF
--- a/web/app/expenses/page.tsx
+++ b/web/app/expenses/page.tsx
@@ -51,13 +51,15 @@ export default function ExpensesPage() {
   const categories = [...new Set(expenses.map((e) => e.category))];
   const allCategories = [
     "食費",
-    "日用品",
     "交通費",
-    "医療費",
-    "娯楽費",
-    "衣服費",
-    "教育費",
+    "日用品",
+    "娯楽",
+    "衣服",
+    "医療・健康",
+    "教育",
     "通信費",
+    "光熱費",
+    "美容・理容",
     "その他",
   ];
 

--- a/web/lib/categoryNormalization.ts
+++ b/web/lib/categoryNormalization.ts
@@ -1,0 +1,128 @@
+export const CANONICAL_CATEGORIES = [
+  '食費',
+  '交通費',
+  '日用品',
+  '娯楽',
+  '衣服',
+  '医療・健康',
+  '教育',
+  '通信費',
+  '光熱費',
+  '美容・理容',
+  'その他',
+];
+
+const ALIAS_TO_CANONICAL: Record<string, string> = {
+  // 食費
+  '外食': '食費',
+  '飲食': '食費',
+  'ランチ': '食費',
+  'ディナー': '食費',
+  '朝食': '食費',
+  'カフェ': '食費',
+  'コンビニ': '食費',
+  'スーパー': '食費',
+
+  // 交通費
+  '交通': '交通費',
+  'ガソリン': '交通費',
+  '駐車場': '交通費',
+  '高速': '交通費',
+  'ETC': '交通費',
+
+  // 日用品
+  '生活用品': '日用品',
+  '消耗品': '日用品',
+  '衛生用品': '日用品',
+  'ドラッグストア': '日用品',
+
+  // 娯楽
+  '娯楽費': '娯楽',
+  'エンタメ': '娯楽',
+  '遊び': '娯楽',
+  'レジャー': '娯楽',
+  '交友費': '娯楽',
+  '交際費': '娯楽',
+  '飲み会': '娯楽',
+
+  // 衣服
+  '衣服費': '衣服',
+  '衣類': '衣服',
+  'ファッション': '衣服',
+  'アパレル': '衣服',
+
+  // 医療・健康
+  '医療': '医療・健康',
+  '医療費': '医療・健康',
+  '健康': '医療・健康',
+  '病院': '医療・健康',
+  '薬': '医療・健康',
+  '調剤': '医療・健康',
+  'クリニック': '医療・健康',
+  '整体': '医療・健康',
+  'マッサージ': '医療・健康',
+  '歯科': '医療・健康',
+  '眼科': '医療・健康',
+
+  // 教育
+  '教育費': '教育',
+  '学習': '教育',
+  '参考書': '教育',
+  '教材': '教育',
+  '書籍': '教育',
+  '本': '教育',
+
+  // 光熱費
+  '公共料金': '光熱費',
+
+  // 通信費
+  '通信費': '通信費',
+  'インターネット': '通信費',
+  '携帯': '通信費',
+  'スマホ': '通信費',
+  '電話': '通信費',
+};
+
+function normalizeString(s?: string): string {
+  return (s || '')
+    .replace(/\s+/g, '')
+    .replace(/費$/, '')
+    .toLowerCase();
+}
+
+export function normalizeCategoryName(
+  input: string | null | undefined,
+  available?: string[]
+): string {
+  const trimmed = (input || '').trim();
+  if (!trimmed) return pickAvailable('その他', available);
+
+  if (available && available.includes(trimmed)) return trimmed;
+  if (CANONICAL_CATEGORIES.includes(trimmed)) return pickAvailable(trimmed, available);
+
+  const norm = normalizeString(trimmed);
+  for (const [alias, canonical] of Object.entries(ALIAS_TO_CANONICAL)) {
+    const a = normalizeString(alias);
+    if (norm.includes(a)) return pickAvailable(canonical, available);
+  }
+
+  // heuristics
+  if (/映画|ゲーム|カラオケ|ボウリング|コンサート|ライブ/.test(trimmed)) return pickAvailable('娯楽', available);
+  if (/薬|病院|クリニック|診療|歯科|整体/.test(trimmed)) return pickAvailable('医療・健康', available);
+  if (/電車|バス|タクシー|ガソリン|駐車場|高速|ETC/i.test(trimmed)) return pickAvailable('交通費', available);
+  if (/ユニクロ|服|衣類|アパレル|ファッション/.test(trimmed)) return pickAvailable('衣服', available);
+  if (/本|書籍|教材|学習|教育/.test(trimmed)) return pickAvailable('教育', available);
+  if (/電気|ガス|水道/.test(trimmed)) return pickAvailable('光熱費', available);
+  if (/通信|インターネット|Wi-?Fi|携帯|スマホ|電話/.test(trimmed)) return pickAvailable('通信費', available);
+  if (/ランチ|ディナー|朝食|カフェ|コンビニ|スーパー|食|弁当/.test(trimmed)) return pickAvailable('食費', available);
+
+  return pickAvailable('その他', available);
+}
+
+function pickAvailable(target: string, available?: string[]): string {
+  if (!available || available.length === 0) return target;
+  if (available.includes(target)) return target;
+  if (available.includes('その他')) return 'その他';
+  return available[0];
+}
+


### PR DESCRIPTION
## 目的
フロントエンド（ダッシュボード/支出編集）のカテゴリを正規化し、重複・類似カテゴリの乱立を防ぎます。Bot側の正規化と揃えて、UIのカテゴリ選択と集計の一貫性を担保します。

## 変更点
- feat: `web/lib/categoryNormalization.ts` を追加
  - 正規カテゴリ一覧（食費/交通費/日用品/娯楽/衣服/医療・健康/教育/通信費/光熱費/美容・理容/その他）
  - 別名→正規カテゴリへのマッピング
- fix: `web/lib/hooks.ts`
  - Firestoreから取得した支出データの `category` をロード時に正規化
  - 更新 (`updateExpense`) 時も正規化して保存 & ローカル状態更新
- fix: `web/app/expenses/page.tsx`
  - 編集フォームのカテゴリプルダウンを正規カテゴリ一覧に更新

## 効果
- フィルター/編集/集計でのカテゴリが統一され、過去データの表示も段階的に収束
- Bot側（AI/ヒューリスティック）出力との不整合を解消

## 確認方法
1. 支出一覧ページで編集ボタンを押下 → カテゴリプルダウンが正規カテゴリのみで構成されること
2. 既存データに「娯楽費」「衣服費」「医療費」等が混在しても、表示時は「娯楽」「衣服」「医療・健康」に揃うこと
3. カテゴリ変更して保存 → 再読込後も正規カテゴリのまま維持されること

## 備考
- 追加の別名・言い回しが分かれば `categoryNormalization` に随時追加可能です。