### PR TITLE
fix: LINEメッセージ処理のエラーハンドリングを改善

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -128,13 +128,18 @@ app.post("/webhook", async (req: Request, res: Response) => {
         console.log("Processing event:", event.type);
 
         if (event.type === "message" && event.message.type === "image") {
-          // 即座に受信確認レスポンス
+          // 即座に受信確認レスポンス（replyMessageを使用）
+          try {
+            await client.replyMessage(event.replyToken, {
+              type: "text",
+              text: "📸 画像を受信しました！処理中です...",
+            });
+          } catch (replyError) {
+            console.warn("Failed to send image receipt confirmation:", replyError);
+          }
+
           const targetId = event.source.type === "group" ? event.source.groupId : event.source.userId;
-          await client.pushMessage(targetId, {
-            type: "text",
-            text: "📸 画像を受信しました！処理中です...",
-          });
-          
+
           // バックグラウンドで処理実行（ノンブロッキング）
           handleImageMessage(event).catch(error => {
             console.error("Image processing error:", error);
@@ -145,27 +150,17 @@ app.post("/webhook", async (req: Request, res: Response) => {
             }).catch(console.error);
           });
         } else if (event.type === "message" && event.message.type === "text") {
-          // テキスト処理も即座レスポンス
-          const targetId = event.source.type === "group" ? event.source.groupId : event.source.userId;
-          
-          // 金額らしきテキストかチェック
-          const hasAmount = /\d+/.test(event.message.text);
-          if (hasAmount) {
-            await client.pushMessage(targetId, {
-              type: "text",
-              text: "💬 テキストを受信しました！処理中です...",
-            });
-          }
-          
+          // テキストメッセージの処理
+          // 注: handleTextMessage内でreplyMessageを使用するため、ここでは送信しない
+
           // バックグラウンドで処理実行
           handleTextMessage(event).catch(error => {
             console.error("Text processing error:", error);
-            if (hasAmount) {
-              client.pushMessage(targetId, {
-                type: "text",
-                text: "❌ テキスト処理中にエラーが発生しました。もう一度お試しください。",
-              }).catch(console.error);
-            }
+            const targetId = event.source.type === "group" ? event.source.groupId : event.source.userId;
+            client.pushMessage(targetId, {
+              type: "text",
+              text: "❌ テキスト処理中にエラーが発生しました。もう一度お試しください。",
+            }).catch(console.error);
           });
         } else if (event.type === "postback") {
           // Postbackイベント処理
@@ -214,39 +209,29 @@ async function handleImageMessage(event: any) {
   const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10MB limit
   const MAX_PROCESSING_TIME = 30000; // 30 seconds
 
+  // 注: 受信確認メッセージはwebhookハンドラーで既に送信済み（pushMessage）
+  // ここではreplyMessageを使用しない（重複メッセージを防ぐため）
+
   try {
-    // Immediately acknowledge image received
-    try {
-      await client.replyMessage(event.replyToken, {
-        type: "text",
-        text: "画像を受信しました！レシートを解析中です...⏳",
-      });
-    } catch (replyError) {
-      console.error("Failed to send immediate reply for image:", replyError);
-    }
-
     // Process image in background (don't await)
-    processImageInBackground(event, MAX_IMAGE_SIZE, MAX_PROCESSING_TIME).catch(
-      (error) => {
-        console.error("Background image processing failed:", error);
-
-        // Send error notification to the source where message came from
-        const targetId =
-          event.source.type === "group"
-            ? event.source.groupId
-            : event.source.userId;
-        client
-          .pushMessage(targetId, {
-            type: "text",
-            text: "画像処理でエラーが発生しました。もう一度お試しください。",
-          })
-          .catch((pushError) =>
-            console.error("Failed to send error notification:", pushError)
-          );
-      }
-    );
+    await processImageInBackground(event, MAX_IMAGE_SIZE, MAX_PROCESSING_TIME);
   } catch (error) {
     console.error("Image message handling error:", error);
+
+    // Send error notification to the source where message came from
+    const targetId =
+      event.source.type === "group"
+        ? event.source.groupId
+        : event.source.userId;
+
+    try {
+      await client.pushMessage(targetId, {
+        type: "text",
+        text: "画像処理でエラーが発生しました。もう一度お試しください。",
+      });
+    } catch (pushError) {
+      console.error("Failed to send error notification:", pushError);
+    }
   }
 }
 
@@ -1235,44 +1220,59 @@ async function handleTextMessage(event: any) {
 
     // ⑥ テキスト登録
     console.log(`=== TEXT PROCESSING: Trying to parse as expense text ===`);
-    const parsed = await parseTextExpense(text);
+    const parsed = parseTextExpense(text);
     if (!parsed) {
       console.log(
-        `=== TEXT PROCESSING: Failed to parse as expense, sending help message ===`
+        `=== TEXT PROCESSING: Failed to parse as expense, ignoring ===`
       );
-      await client.replyMessage(event.replyToken, {
-        type: "text",
-        text: "💡 金額が見つかりませんでした。\n例: 「500 ランチ」「1200 交通費」",
-      });
+      // 金額が見つからない場合は無視（コマンドでもない一般的なテキスト）
+      // replyMessageを送らないことで、エラーを防ぐ
       return;
     }
 
     console.log(`=== TEXT PROCESSING: Successfully parsed expense:`, parsed);
 
-    // 即座に処理中のメッセージを返す（Flex Messageは後で送信）
-    // 注: replyTokenは既に「💬 テキストを受信しました！処理中です...」で使用済みの場合あり
-    // そのため、ここでは追加のreplyMessageは送信しない
+    // 即座に処理中のメッセージを返す
+    const targetId = event.source.type === "group"
+      ? event.source.groupId
+      : event.source.userId;
 
-    // Process expense registration in background (don't await)
-    processExpenseInBackground(event, parsed).catch((error) => {
+    try {
+      await client.replyMessage(event.replyToken, {
+        type: "text",
+        text: "💬 登録中です...",
+      });
+    } catch (replyError) {
+      console.warn("Failed to send processing confirmation:", replyError);
+    }
+
+    // Process expense registration
+    try {
+      await processExpenseInBackground(event, parsed);
+    } catch (error) {
       console.error("Background expense processing failed:", error);
-
-      // Send error notification to the source where message came from
-      const targetId =
-        event.source.type === "group"
-          ? event.source.groupId
-          : event.source.userId;
-      client
-        .pushMessage(targetId, {
-          type: "text",
-          text: "⚠️ 支出の保存で問題が発生しました。データが正しく記録されていない可能性があります。",
-        })
-        .catch((pushError) =>
-          console.error("Failed to send error notification:", pushError)
-        );
-    });
+      // Send error notification
+      await client.pushMessage(targetId, {
+        type: "text",
+        text: "⚠️ 支出の保存で問題が発生しました。データが正しく記録されていない可能性があります。",
+      }).catch((pushError) =>
+        console.error("Failed to send error notification:", pushError)
+      );
+    }
   } catch (error) {
     console.error("Text message handling error:", error);
+    // エラーが発生した場合、可能であればユーザーに通知
+    try {
+      const targetId = event.source.type === "group"
+        ? event.source.groupId
+        : event.source.userId;
+      await client.pushMessage(targetId, {
+        type: "text",
+        text: "⚠️ メッセージの処理中にエラーが発生しました。もう一度お試しください。",
+      });
+    } catch (notifyError) {
+      console.error("Failed to send error notification:", notifyError);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- 画像送信・手入力時に「申し訳ございませんが、一時的なエラーが発生しました」エラーを修正
- webhookハンドラーでの重複メッセージ送信を解消
- エラーハンドリングの改善により、例外発生時も適切にユーザーへ通知

## 問題の原因

1. **重複したreplyMessage呼び出し**: webhookハンドラー(133行目)で`pushMessage`を送信後、`handleImageMessage`内(220行目)で`replyMessage`を呼び出していた
2. **テキスト処理のreplyToken問題**: 金額を含むテキストの場合、`pushMessage`で処理中メッセージを送信後、`parseTextExpense`が失敗すると`replyMessage`でヘルプを送ろうとしていた
3. **非同期処理のエラー伝播**: `.catch()`で処理されるエラーが外側のtry-catchに到達せず、エラーメッセージが重複送信される可能性があった

## 修正内容

### 画像メッセージ処理
- 受信確認を`replyMessage`に統一（webhookハンドラーで送信）
- `handleImageMessage`から重複した受信確認メッセージを削除
- エラー時は`pushMessage`で通知

### テキストメッセージ処理  
- 金額が見つからない場合は無視（ヘルプメッセージを送信しない）
- 金額が見つかった場合は`replyMessage`で「💬 登録中です...」を送信
- `processExpenseInBackground`をawaitして同期的にエラーをキャッチ
- catchブロックでもユーザーへエラー通知を送信

## Test plan

- [ ] 画像送信で正常に登録できることを確認
- [ ] 「500 ランチ」のようなテキスト入力で正常に登録できることを確認  
- [ ] 「家計簿」コマンドが正常に動作することを確認
- [ ] Gmail自動連携が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 画像・テキスト処理のエラーハンドリングを改善し、失敗時の通知が一貫して送信されるようにしました。

* **New Features**
  * テキスト送信時に即座に「💬 登録中です...」と確認メッセージを表示します。

* **Improvements**
  * 不要な中間通知を削減して通知フローを簡素化。
  * 解析できないテキストは静かに無視されるようになり、誤通知が減少します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->