### PR TITLE
fix: 廃止されたGemini APIモデルをgemini-2.5-flashに更新

### DIFF
--- a/bot/src/enhancedCategoryClassifier.ts
+++ b/bot/src/enhancedCategoryClassifier.ts
@@ -101,7 +101,7 @@ export async function classifyWithContext(
     const learningPatterns = buildLearningPatterns(userFeedbackHistory);
     const contextHints = buildContextHints(context);
     
-    const model = client.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const model = client.getGenerativeModel({ model: "gemini-2.5-flash" });
 
     const prompt = `
 あなたは日本の家計簿のカテゴリ分類の専門家です。以下の支出情報を最も適切なカテゴリに分類してください。
@@ -323,7 +323,7 @@ export async function batchClassify(
   try {
     const availableCategories = await getAllUserCategories(lineId);
     const categoryNames = availableCategories.map(cat => cat.name);
-    const model = client.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const model = client.getGenerativeModel({ model: "gemini-2.5-flash" });
     
     const prompt = `
 以下の複数の支出を適切なカテゴリに分類してください。

--- a/bot/src/geminiCategoryClassifier.ts
+++ b/bot/src/geminiCategoryClassifier.ts
@@ -150,7 +150,7 @@ export async function classifyExpenseWithGemini(
     }
     
     // Geminiモデルを取得
-    const model = client.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const model = client.getGenerativeModel({ model: "gemini-2.5-flash" });
 
     // Few-shot学習形式の高精度プロンプト
     const prompt = `あなたは家計簿の支出分類の専門家です。以下の支出内容を最も適切なカテゴリに正確に分類してください。


### PR DESCRIPTION
## Summary
- `gemini-1.5-flash`（2025年9月29日に廃止済み）を`gemini-2.5-flash`に更新
- geminiCategoryClassifier.ts と enhancedCategoryClassifier.ts のモデル指定を修正
- カテゴリ分類の成功率が0%だった問題を解消

## Test plan
- [ ] `/test-classification` エンドポイントでカテゴリ分類が正常動作することを確認
- [ ] `/classification-stats` で成功率が0%でないことを確認

https://claude.ai/code/session_017Siw3cG8ziQufoEaPhTDdZ