### PR TITLE
chore: Firebase Storageのセキュリティルールをコード管理化

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,5 +16,8 @@
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
+  },
+  "storage": {
+    "rules": "storage.rules"
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,10 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /receipts/{expenseId}/{fileName} {
+      allow read: if true;
+      allow write: if request.resource.size < 10 * 1024 * 1024
+                   && request.resource.contentType.matches('image/.*');
+    }
+  }
+}

--- a/web/lib/firebase.ts
+++ b/web/lib/firebase.ts
@@ -19,7 +19,7 @@ const config: FirebaseConfig = {
   apiKey: (process.env.NEXT_PUBLIC_FIREBASE_API_KEY || "").trim(),
   authDomain: (process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || "line-kakeibo-0410.firebaseapp.com").trim(),
   projectId: (process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || "line-kakeibo-0410").trim(),
-  storageBucket: (process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "line-kakeibo-0410.appspot.com").trim(),
+  storageBucket: (process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "line-kakeibo-0410.firebasestorage.app").trim(),
   messagingSenderId: (process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || "440748785600").trim(),
   appId: (process.env.NEXT_PUBLIC_FIREBASE_APP_ID || "").trim(),
   measurementId: (process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID || "G-PLNC7GY160").trim(),


### PR DESCRIPTION
## 📋 変更内容

Firebase Storageのセキュリティルールをリポジトリで管理できるよう `storage.rules` を追加し、`firebase deploy --only storage` でデプロイ可能にしました。あわせてStorageバケット名のフォールバックを実バケットに合わせて修正しました。

## 🎯 目的・背景

レシート添付機能（#85）では `receipts/{expenseId}/{timestamp}_{ファイル名}` にアップロードしますが、Storageルールは Firebase Console で手動設定されているだけで、コード管理されていませんでした。Firestore（`firestore.rules`）と同様にコードで一元管理できるようにします。

なお Storage 有効化時に作成された実バケットは新形式 `line-kakeibo-0410.firebasestorage.app` でしたが、設定は旧形式 `line-kakeibo-0410.appspot.com` を指しておりアップロードが失敗する状態だったため、これも修正しています。

## 🔧 変更種別

- [x] 🔧 設定・ツール (Configuration/Tools)
- [x] 🔒 セキュリティ (Security)
- [x] 🐛 バグ修正 (Bug fix)

## 主な変更点

- **`storage.rules`（新規）**: `receipts/{expenseId}/{fileName}` のルールを定義
  - `read`: 許可（Firestoreルールと同方針。本アプリはFirebase Auth未使用）
  - `write`: 画像（`image/.*`）かつ 10MB 未満のみ許可
- **`firebase.json`**: `storage.rules` を参照する `storage` セクションを追加（`functions`/`firestore` と同階層）
- **`web/lib/firebase.ts`**: `storageBucket` フォールバックを `appspot.com` → `firebasestorage.app` に修正（実バケットと一致）

## 🧪 テスト

- [x] ローカルでの動作確認済み（`firebase deploy --only storage` でルールがコンパイル成功・デプロイ完了）
- [ ] 新しいテストケースを追加した（ルール定義のみのため対象外）
- [x] 既存テストが全て通ることを確認した（コード変更は文字列フォールバック1行のみ）

### アップロード実装との整合性

| 項目 | attachページ実装 | storage.rules |
|---|---|---|
| パス | `receipts/${expenseId}/${timestamp}_${safeName}` | `receipts/{expenseId}/{fileName}` ✓ |
| contentType | `selectedFile.type`（image/*） | `contentType.matches('image/.*')` ✓ |
| サイズ | — | `size < 10MB`（サーバ側で拒否）✓ |

## 📱 動作環境

- [x] Web (Vercel)
- [x] データベース (Firestore) ※Storage

## 🔗 関連Issue

- Related to #85

## ⚠️ 注意事項

- 本番（Vercel）の環境変数 `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` も `line-kakeibo-0410.firebasestorage.app` に更新済み。
- Storageルールは既にデプロイ済み（このPRはルールのコード管理化が目的）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Firebase Cloud Storageの統合が有効化されました。
  * レシート画像のアップロード機能が実装されました。JPG/PNG形式のファイルで、10MB以下のファイルをアップロードできます。
  * アップロード済みのレシートはいつでも読み込み可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->