### PR TITLE
fix: Firestoreの自動ロングポーリングで"client is offline"を解消

### DIFF
--- a/web/lib/firebase.ts
+++ b/web/lib/firebase.ts
@@ -109,8 +109,14 @@ const initializeFirebase = () => {
     // 自動でロングポーリングへフォールバックさせて接続性を確保する。
     try {
       db = initializeFirestore(app, { experimentalAutoDetectLongPolling: true });
-    } catch {
-      // 既に初期化済み（HMR等での二重初期化）の場合は既存インスタンスを再利用
+    } catch (error) {
+      // 通常ここに来るのは「Firestoreが既に初期化済み」(HMR等の二重初期化)のみで、
+      // その場合 getFirestore(app) は long-polling 付きで生成済みの既存インスタンスを返す。
+      // 観測性のため、フォールバックが発生した事実とエラー内容を必ずログに残す。
+      console.warn(
+        'initializeFirestore failed; falling back to getFirestore (long-polling preserved if already initialized):',
+        error
+      );
       db = getFirestore(app);
     }
     

--- a/web/lib/firebase.ts
+++ b/web/lib/firebase.ts
@@ -1,5 +1,5 @@
 import { initializeApp, getApps, getApp } from 'firebase/app';
-import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
+import { getFirestore, initializeFirestore, connectFirestoreEmulator } from 'firebase/firestore';
 import { getAuth, signInAnonymously, UserCredential } from 'firebase/auth';
 import { getStorage } from 'firebase/storage';
 
@@ -104,7 +104,15 @@ const initializeFirebase = () => {
     }
     
     // Firestore初期化
-    db = getFirestore(app);
+    // WebView/プロキシ/拡張機能などでWebChannelストリーミングがブロックされると
+    // "Failed to get document because the client is offline" になる。
+    // 自動でロングポーリングへフォールバックさせて接続性を確保する。
+    try {
+      db = initializeFirestore(app, { experimentalAutoDetectLongPolling: true });
+    } catch {
+      // 既に初期化済み（HMR等での二重初期化）の場合は既存インスタンスを再利用
+      db = getFirestore(app);
+    }
     
     // Emulator接続（開発環境のみ）
     if (process.env.NODE_ENV === 'development' && process.env.NEXT_PUBLIC_USE_FIREBASE_EMULATOR === 'true') {


### PR DESCRIPTION
## 📋 変更内容

Firestore初期化を `getFirestore(app)` から `initializeFirestore(app, { experimentalAutoDetectLongPolling: true })` に変更し、WebChannelストリーミングが使えない環境で自動的にロングポーリングへフォールバックするようにしました。

## 🎯 目的・背景

一部のブラウザ環境で、支出・予算・日付設定などのデータが**一切読み込めない**事象が発生していました。コンソールには次のエラー:

```
FirebaseError: Failed to get document because the client is offline.
```

これは Firestore Web SDK が **WebChannel（ストリーミング）でバックエンドに接続できない**ときに出るエラーです。LINEアプリ内ブラウザ(WebView)、プロキシ、広告ブロッカー/プライバシー拡張などがストリーミング接続を遮断すると発生します。

### 切り分け（原因はクライアント通信層に限定と確認済み）

Web SDK を本番と同一設定で Node から実行し、アプリが実際に投げる全クエリを再現したところ **すべて成功**:

| 検証 | 結果 |
|---|---|
| 履歴全件 `lineId` | ✅ 147件 |
| 月次stats `lineId`+`date` | ✅ |
| グループ `lineGroupId`+`date`（複合index） | ✅ 37件 |
| `budgetSettings` / `userSettings` 読み取り | ✅（ルール拒否なし） |
| バンドル内Firebase設定(apiKey等) | ✅ 埋め込み済み |

→ データ・ルール・インデックス・設定はすべて正常。残るはクライアントの通信トランスポートのみ、と特定。

## 🔧 変更種別

- [x] 🐛 バグ修正 (Bug fix)

## 主な変更

```diff
- db = getFirestore(app);
+ try {
+   db = initializeFirestore(app, { experimentalAutoDetectLongPolling: true });
+ } catch {
+   db = getFirestore(app); // HMR等の二重初期化フォールバック
+ }
```

`experimentalAutoDetectLongPolling` はストリーミングが通る環境では従来通り動作し、ブロックされた場合のみロングポーリングに切替わるため低リスクです。

## 🧪 テスト

- [x] `tsc --noEmit`：本変更起因の型エラーなし（既存のrecharts型エラーのみ）
- [ ] 本番デプロイ後、該当環境（LINE WebView等）でデータ表示を確認

## 📱 動作環境

- [x] Web (Vercel)
- [x] データベース (Firestore)

## ⚠️ 注意事項

- 本番反映には Vercel への master マージ＝デプロイが必要です。
- マージ後、データが読めなかった環境で再確認をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Firebase Firestore の接続処理を改善しました。特定の環境で発生する接続性の問題に対応するため、自動フォールバック機構を追加しました。接続が失敗した場合、システムは自動的に長時間ポーリングにフォールバックして、より安定した接続を実現します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->