### PR TITLE
feat: 支出一覧からレシートを添付できるリンクを追加

### DIFF
--- a/web/app/expenses/page.tsx
+++ b/web/app/expenses/page.tsx
@@ -1076,7 +1076,7 @@ function ExpensesPageContent() {
                           </a>
                         ) : (
                           <a
-                            href={`/attach?expenseId=${expense.id}${lineIdFromUrl ? `&lineId=${encodeURIComponent(lineIdFromUrl)}` : ""}`}
+                            href={`/attach?expenseId=${encodeURIComponent(expense.id)}`}
                             className="bg-gray-100 text-gray-700 text-xs font-medium px-2.5 py-0.5 rounded hover:bg-gray-200 transition-colors cursor-pointer"
                             title="レシートを添付"
                           >

--- a/web/app/expenses/page.tsx
+++ b/web/app/expenses/page.tsx
@@ -1064,7 +1064,7 @@ function ExpensesPageContent() {
                             合計から除外
                           </span>
                         )}
-                        {expense.receiptUrl && (
+                        {expense.receiptUrl ? (
                           <a
                             href={expense.receiptUrl}
                             target="_blank"
@@ -1073,6 +1073,14 @@ function ExpensesPageContent() {
                             title="レシート画像を開く"
                           >
                             📎 レシート
+                          </a>
+                        ) : (
+                          <a
+                            href={`/attach?expenseId=${expense.id}${lineIdFromUrl ? `&lineId=${encodeURIComponent(lineIdFromUrl)}` : ""}`}
+                            className="bg-gray-100 text-gray-700 text-xs font-medium px-2.5 py-0.5 rounded hover:bg-gray-200 transition-colors cursor-pointer"
+                            title="レシートを添付"
+                          >
+                            📎 レシート添付
                           </a>
                         )}
                       </div>


### PR DESCRIPTION
## 📋 変更内容

Web の支出一覧（`/expenses`）で、**レシート未添付の支出に「📎 レシート添付」リンク**を追加しました。クリックで `/attach?expenseId=...` に遷移し、その場で画像を添付できます。

## 🎯 目的・背景

これまでレシート添付の導線は **LINEの支出カードのボタンのみ**で、Web側からは添付できませんでした（一覧には添付済みの「📎 レシート」=画像を開くリンクしか無い）。Webからも添付したいニーズに対応します。

## 🔧 変更種別

- [x] ✨ 新機能 (New feature)
- [x] 💄 UI/UX改善

## 主な変更

`web/app/expenses/page.tsx` のバッジ表示を分岐:
- `receiptUrl` あり → 従来どおり「📎 レシート」（画像を開く）
- `receiptUrl` なし → 「📎 レシート添付」リンク（`/attach?expenseId=${id}` ＋ あれば `lineId` を付与）

```diff
- {expense.receiptUrl && (<a ...>📎 レシート</a>)}
+ {expense.receiptUrl ? (
+   <a ...>📎 レシート</a>
+ ) : (
+   <a href={`/attach?expenseId=${expense.id}${lineIdFromUrl ? `&lineId=...` : ""}`}>📎 レシート添付</a>
+ )}
```

`/attach` ページは既存実装をそのまま利用（追加・改修なし）。

## 🧪 テスト

- [x] `tsc --noEmit`：本変更起因の型エラーなし
- [ ] 一覧で未添付支出にリンク表示 → 遷移 → 添付 → 戻ると「📎 レシート」化、を本番で確認

## 📱 動作環境

- [x] Web (Vercel)

## ⚠️ 注意事項

- 添付先は従来と同じ `receipts/{expenseId}/...`（`storage.rules` 適用済み）。
- いまは1支出1枚（差し替え可）。複数枚対応は別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 支出画面のレシート表示を改善。レシート画像がある場合はその画像へのリンク、ない場合は「レシート添付」のリンクが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->