### PR TITLE
feat(ui): 設定・添付・ゲスト導線の刷新（UI刷新 Phase 4/4・最終）

### DIFF
--- a/web/app/attach/page.tsx
+++ b/web/app/attach/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
+import { Paperclip, Check, RefreshCw, Camera, Upload } from "lucide-react";
 import { doc, getDoc, updateDoc } from "firebase/firestore";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { db, storage, ensureFirebaseInitialized } from "../../lib/firebase";
@@ -18,11 +19,8 @@ export default function AttachPage() {
 
 function AttachPageLoading() {
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="text-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-        <p className="mt-4 text-gray-600">読み込み中...</p>
-      </div>
+    <div className="flex min-h-dvh items-center justify-center">
+      <div className="h-9 w-9 animate-spin rounded-full border-2 border-accent border-t-transparent" />
     </div>
   );
 }
@@ -176,32 +174,35 @@ function AttachPageContent() {
   const showUploadForm = !hasReceipt || replacing;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
-      <div className="bg-white shadow-sm">
-        <div className="max-w-lg mx-auto px-4 py-4">
-          <h1 className="text-xl font-bold text-gray-900">📎 レシート添付</h1>
+    <div className="min-h-dvh">
+      <header className="glass-bar sticky top-0 z-10 border-b border-line/60">
+        <div className="mx-auto flex max-w-lg items-center gap-2 px-4 py-4">
+          <span className="grid h-8 w-8 place-items-center rounded-xl bg-accent text-accent-fg">
+            <Paperclip className="h-[18px] w-[18px]" strokeWidth={2.2} />
+          </span>
+          <h1 className="text-lg font-semibold tracking-tight text-fg">レシート添付</h1>
         </div>
-      </div>
+      </header>
 
-      <main className="max-w-lg mx-auto px-4 py-6 space-y-6">
+      <main className="mx-auto max-w-lg space-y-4 px-4 py-6">
         {error && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-            <p className="text-red-800 text-sm">{error}</p>
+          <div className="rounded-2xl border border-rose-500/20 bg-rose-500/[0.06] p-4">
+            <p className="text-sm text-rose-600 dark:text-rose-400">{error}</p>
           </div>
         )}
 
         {expense && (
           <>
             {/* 支出概要 */}
-            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
-              <h2 className="text-sm font-medium text-gray-500 mb-3">対象の支出</h2>
-              <p className="text-lg font-semibold text-gray-900 break-words">
+            <div className="glass rounded-2xl p-5 shadow-glass">
+              <h2 className="mb-3 text-sm font-medium text-muted">対象の支出</h2>
+              <p className="break-words text-lg font-semibold text-fg">
                 {expense.description}
               </p>
-              <p className="text-2xl font-bold text-red-600 mt-1">
+              <p className="mt-1 text-2xl font-bold tabular-nums text-fg">
                 ¥{expense.amount.toLocaleString()}
               </p>
-              <p className="text-sm text-gray-600 mt-1">
+              <p className="mt-1 text-sm text-muted">
                 {expense.date
                   ? dayjs(expense.date).format("YYYY年M月D日")
                   : "日付不明"}
@@ -211,17 +212,16 @@ function AttachPageContent() {
 
             {/* アップロード完了メッセージ */}
             {uploadDone && (
-              <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-                <p className="text-green-800 text-sm font-medium">
-                  ✅ レシートを添付しました！このページは閉じて構いません。
-                </p>
+              <div className="flex items-start gap-2 rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.08] p-4 text-emerald-700 dark:text-emerald-300">
+                <Check className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={2.4} />
+                <p className="text-sm font-medium">レシートを添付しました。このページは閉じて構いません。</p>
               </div>
             )}
 
             {/* 既存レシートのプレビュー */}
             {hasReceipt && (
-              <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
-                <h2 className="text-sm font-medium text-gray-500 mb-3">
+              <div className="glass rounded-2xl p-5 shadow-glass">
+                <h2 className="mb-3 text-sm font-medium text-muted">
                   添付済みのレシート
                 </h2>
                 {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -229,7 +229,7 @@ function AttachPageContent() {
                   <img
                     src={expense.receiptUrl}
                     alt="添付済みレシート"
-                    className="w-full rounded-lg border border-gray-200"
+                    className="w-full rounded-lg border border-line"
                   />
                 )}
                 {!replacing && (
@@ -239,9 +239,10 @@ function AttachPageContent() {
                       setReplacing(true);
                       setUploadDone(false);
                     }}
-                    className="mt-4 w-full bg-gray-500 text-white px-4 py-3 rounded-lg text-sm font-medium hover:bg-gray-600 transition-colors"
+                    className="mt-4 flex w-full items-center justify-center gap-1.5 rounded-lg border border-line bg-card px-4 py-3 text-sm font-medium text-fg transition-colors hover:bg-fg/5"
                   >
-                    🔄 レシートを差し替える
+                    <RefreshCw className="h-4 w-4" />
+                    レシートを差し替える
                   </button>
                 )}
               </div>
@@ -249,8 +250,8 @@ function AttachPageContent() {
 
             {/* アップロードフォーム */}
             {showUploadForm && (
-              <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-5 space-y-4">
-                <h2 className="text-sm font-medium text-gray-500">
+              <div className="glass space-y-4 rounded-2xl p-5 shadow-glass">
+                <h2 className="text-sm font-medium text-muted">
                   {hasReceipt ? "新しいレシートを選択" : "レシート画像を選択"}
                 </h2>
 
@@ -266,24 +267,26 @@ function AttachPageContent() {
                 <button
                   type="button"
                   onClick={() => fileInputRef.current?.click()}
-                  className="w-full border-2 border-dashed border-gray-300 rounded-lg p-6 text-center hover:border-blue-400 hover:bg-blue-50 transition-colors"
+                  className="flex w-full flex-col items-center gap-2 rounded-xl border-2 border-dashed border-line p-6 text-center transition-colors hover:border-accent hover:bg-accent/[0.04]"
                 >
-                  <span className="text-3xl block mb-2">📷</span>
-                  <span className="text-sm text-gray-600">
+                  <span className="grid h-12 w-12 place-items-center rounded-2xl bg-accent/12 text-accent">
+                    <Camera className="h-6 w-6" strokeWidth={1.9} />
+                  </span>
+                  <span className="text-sm text-muted">
                     タップして撮影 / 画像を選択
                   </span>
                 </button>
 
                 {previewDataUrl && (
                   <div>
-                    <h3 className="text-sm font-medium text-gray-500 mb-2">
+                    <h3 className="mb-2 text-sm font-medium text-muted">
                       プレビュー
                     </h3>
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={previewDataUrl}
                       alt="選択した画像のプレビュー"
-                      className="w-full rounded-lg border border-gray-200"
+                      className="w-full rounded-lg border border-line"
                     />
                   </div>
                 )}
@@ -292,13 +295,10 @@ function AttachPageContent() {
                   type="button"
                   onClick={handleUpload}
                   disabled={!selectedFile || uploading}
-                  className={`w-full px-4 py-3 rounded-lg text-sm font-medium transition-colors ${
-                    !selectedFile || uploading
-                      ? "bg-gray-300 text-gray-500 cursor-not-allowed"
-                      : "bg-blue-600 text-white hover:bg-blue-700"
-                  }`}
+                  className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-accent px-4 py-3 text-sm font-medium text-accent-fg transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
                 >
-                  {uploading ? "アップロード中..." : "⬆️ アップロードする"}
+                  <Upload className="h-4 w-4" />
+                  {uploading ? "アップロード中..." : "アップロードする"}
                 </button>
 
                 {replacing && (
@@ -309,7 +309,7 @@ function AttachPageContent() {
                       setSelectedFile(null);
                       setPreviewDataUrl(null);
                     }}
-                    className="w-full bg-white text-gray-600 border border-gray-300 px-4 py-3 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors"
+                    className="w-full rounded-lg border border-line bg-card px-4 py-3 text-sm font-medium text-fg transition-colors hover:bg-fg/5"
                   >
                     キャンセル
                   </button>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -2,11 +2,13 @@
 
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
+import { Wallet, CalendarRange } from 'lucide-react';
 import { useLineAuth } from '../../lib/hooks';
 import { getDateRangeSettings, saveDateRangeSettings, migrateLocalToFirestore, DEFAULT_SETTINGS, type DateRangeSettings } from '../../lib/dateSettings';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
 import PreviewModeBanner from '../../components/PreviewModeBanner';
+import { getCategoryVisual } from '../../lib/categoryVisuals';
 import dayjs from 'dayjs';
 
 // 予算設定インターフェース
@@ -23,16 +25,16 @@ const defaultBudgetConfig: BudgetConfig = {
 };
 
 const defaultCategories = [
-  { id: 'food', name: '食費', emoji: '🍽️' },
-  { id: 'daily', name: '日用品', emoji: '🛒' },
-  { id: 'transport', name: '交通費', emoji: '🚃' },
-  { id: 'entertainment', name: '娯楽費', emoji: '🎮' },
-  { id: 'utility', name: '光熱費', emoji: '💡' },
-  { id: 'communication', name: '通信費', emoji: '📱' },
-  { id: 'medical', name: '医療費', emoji: '🏥' },
-  { id: 'clothing', name: '衣服費', emoji: '👕' },
-  { id: 'education', name: '教育費', emoji: '📚' },
-  { id: 'other', name: 'その他', emoji: '📦' },
+  { id: 'food', name: '食費' },
+  { id: 'daily', name: '日用品' },
+  { id: 'transport', name: '交通費' },
+  { id: 'entertainment', name: '娯楽費' },
+  { id: 'utility', name: '光熱費' },
+  { id: 'communication', name: '通信費' },
+  { id: 'medical', name: '医療費' },
+  { id: 'clothing', name: '衣服費' },
+  { id: 'education', name: '教育費' },
+  { id: 'other', name: 'その他' },
 ];
 
 function normalizeBudgetConfig(data: unknown): BudgetConfig {
@@ -182,10 +184,10 @@ export default function Settings() {
 
   if (authLoading || loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-gray-100">
+      <div className="flex min-h-[60vh] items-center justify-center">
         <div className="text-center">
-          <div className="w-10 h-10 border-3 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto"></div>
-          <p className="mt-4 text-sm text-gray-500">読み込み中...</p>
+          <div className="mx-auto h-9 w-9 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+          <p className="mt-3 text-sm text-muted">読み込み中...</p>
         </div>
       </div>
     );
@@ -193,13 +195,13 @@ export default function Settings() {
 
   if (!user) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-gray-100">
-        <div className="text-center max-w-md p-8 bg-white rounded-2xl shadow-lg">
-          <h1 className="text-xl font-bold text-gray-900 mb-2">ログインが必要です</h1>
-          <p className="text-gray-600 text-sm mb-4">設定を変更するにはログインしてください</p>
+      <div className="mx-auto flex min-h-[60vh] max-w-md items-center px-4">
+        <div className="glass w-full rounded-2xl p-8 text-center shadow-glass">
+          <h1 className="text-lg font-semibold text-fg">ログインが必要です</h1>
+          <p className="mt-1.5 text-sm text-muted">設定を変更するにはログインしてください</p>
           <a
             href={getUrlWithLineId('/')}
-            className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+            className="mt-4 inline-flex items-center rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-fg transition-colors hover:opacity-90"
           >
             ホームに戻る
           </a>
@@ -209,10 +211,14 @@ export default function Settings() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50">
-      {(user.uid === 'guest' || user.isAnonymous) && <PreviewModeBanner />}
+    <div className="mx-auto w-full max-w-2xl px-4 py-5 md:px-8 md:py-7">
+      {(user.uid === 'guest' || user.isAnonymous) && (
+        <div className="mb-4">
+          <PreviewModeBanner />
+        </div>
+      )}
 
-      <main className="max-w-2xl mx-auto px-4 py-6 pb-24">
+      <main>
         {/* Message */}
         {message && (
           <motion.div
@@ -220,8 +226,8 @@ export default function Settings() {
             animate={{ opacity: 1, y: 0 }}
             className={`mb-4 p-3 rounded-xl text-sm ${
               message.type === 'success'
-                ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
-                : 'bg-rose-50 text-rose-700 border border-rose-200'
+                ? 'border border-emerald-500/20 bg-emerald-500/12 text-emerald-700 dark:text-emerald-300'
+                : 'border border-rose-500/20 bg-rose-500/12 text-rose-700 dark:text-rose-300'
             }`}
           >
             {message.text}
@@ -229,26 +235,28 @@ export default function Settings() {
         )}
 
         {/* Tab Navigation */}
-        <div className="flex gap-2 mb-6 bg-white/80 backdrop-blur-sm rounded-xl p-1 shadow-sm border border-gray-100">
+        <div className="glass mb-5 flex gap-1 rounded-2xl p-1 shadow-glass">
           <button
             onClick={() => setActiveTab('budget')}
-            className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-all ${
+            className={`flex flex-1 items-center justify-center gap-1.5 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors ${
               activeTab === 'budget'
-                ? 'bg-blue-600 text-white shadow-sm'
-                : 'text-gray-600 hover:bg-gray-100'
+                ? 'bg-accent text-accent-fg shadow-sm'
+                : 'text-muted hover:bg-fg/5 hover:text-fg'
             }`}
           >
-            💰 予算設定
+            <Wallet className="h-4 w-4" />
+            予算設定
           </button>
           <button
             onClick={() => setActiveTab('period')}
-            className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-all ${
+            className={`flex flex-1 items-center justify-center gap-1.5 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors ${
               activeTab === 'period'
-                ? 'bg-blue-600 text-white shadow-sm'
-                : 'text-gray-600 hover:bg-gray-100'
+                ? 'bg-accent text-accent-fg shadow-sm'
+                : 'text-muted hover:bg-fg/5 hover:text-fg'
             }`}
           >
-            📅 期間設定
+            <CalendarRange className="h-4 w-4" />
+            期間設定
           </button>
         </div>
 
@@ -260,10 +268,10 @@ export default function Settings() {
             className="space-y-4"
           >
             {/* Monthly Budget */}
-            <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-sm border border-gray-100 p-5">
-              <h3 className="text-sm font-semibold text-gray-900 mb-3">月間予算総額</h3>
+            <div className="glass rounded-2xl shadow-glass p-5">
+              <h3 className="text-sm font-semibold text-fg mb-3">月間予算総額</h3>
               <div className="relative">
-                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">¥</span>
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted">¥</span>
                 <input
                   type="number"
                   value={budgetConfig.monthlyBudget}
@@ -272,14 +280,14 @@ export default function Settings() {
                     const value = Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
                     setBudgetConfig(prev => ({ ...prev, monthlyBudget: value }));
                   }}
-                  className="w-full pl-8 pr-4 py-3 rounded-xl border border-gray-200 text-lg font-bold text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full rounded-xl border border-line bg-card py-3 pl-8 pr-4 text-lg font-bold text-fg focus:border-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 />
               </div>
             </div>
 
             {/* Alert Threshold */}
-            <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-sm border border-gray-100 p-5">
-              <h3 className="text-sm font-semibold text-gray-900 mb-3">予算残り警告</h3>
+            <div className="glass rounded-2xl shadow-glass p-5">
+              <h3 className="text-sm font-semibold text-fg mb-3">予算残り警告</h3>
               <div className="flex items-center gap-4">
                 <input
                   type="range"
@@ -290,31 +298,36 @@ export default function Settings() {
                   onChange={(e) => setBudgetConfig(prev => ({ ...prev, alertThreshold: parseInt(e.target.value) }))}
                   className="flex-1"
                 />
-                <span className="w-14 text-center font-semibold text-gray-900">
+                <span className="w-14 text-center font-semibold text-fg">
                   {budgetConfig.alertThreshold}%
                 </span>
               </div>
-              <p className="text-xs text-gray-500 mt-2">
+              <p className="text-xs text-muted mt-2">
                 残り予算が{budgetConfig.alertThreshold}%（¥{Math.round(budgetConfig.monthlyBudget * budgetConfig.alertThreshold / 100).toLocaleString()}）を下回ると警告
               </p>
             </div>
 
             {/* Category Budgets */}
-            <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-sm border border-gray-100 p-5">
+            <div className="glass rounded-2xl shadow-glass p-5">
               <div className="flex justify-between items-center mb-4">
-                <h3 className="text-sm font-semibold text-gray-900">カテゴリ別予算</h3>
-                <span className={`text-xs ${categoryBudgetTotal > budgetConfig.monthlyBudget ? 'text-rose-500' : 'text-gray-500'}`}>
+                <h3 className="text-sm font-semibold text-fg">カテゴリ別予算</h3>
+                <span className={`text-xs ${categoryBudgetTotal > budgetConfig.monthlyBudget ? 'text-rose-500' : 'text-muted'}`}>
                   合計: ¥{categoryBudgetTotal.toLocaleString()}
                 </span>
               </div>
 
               <div className="space-y-3">
-                {defaultCategories.map((category) => (
+                {defaultCategories.map((category) => {
+                  const v = getCategoryVisual(category.name);
+                  const Icon = v.icon;
+                  return (
                   <div key={category.id} className="flex items-center gap-3">
-                    <span className="text-lg w-7">{category.emoji}</span>
-                    <span className="w-16 text-sm text-gray-700 truncate">{category.name}</span>
-                    <div className="flex-1 relative">
-                      <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400 text-sm">¥</span>
+                    <span className={`grid h-7 w-7 flex-shrink-0 place-items-center rounded-lg ${v.bg} ${v.fg}`}>
+                      <Icon className="h-4 w-4" strokeWidth={2.1} />
+                    </span>
+                    <span className="w-16 truncate text-sm text-fg">{category.name}</span>
+                    <div className="relative flex-1">
+                      <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted">¥</span>
                       <input
                         type="number"
                         placeholder="0"
@@ -329,11 +342,12 @@ export default function Settings() {
                             },
                           }));
                         }}
-                        className="w-full pl-7 pr-3 py-2 rounded-lg border border-gray-200 text-sm text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                        className="w-full rounded-lg border border-line bg-card py-2 pl-7 pr-3 text-sm text-fg focus:border-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       />
                     </div>
                   </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           </motion.div>
@@ -344,89 +358,89 @@ export default function Settings() {
           <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
-            className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-sm border border-gray-100 p-5"
+            className="glass rounded-2xl shadow-glass p-5"
           >
-            <h3 className="text-sm font-semibold text-gray-900 mb-4">表示期間の設定</h3>
+            <h3 className="text-sm font-semibold text-fg mb-4">表示期間の設定</h3>
 
             <div className="space-y-3">
-              <label className="flex items-center p-3 rounded-xl border border-gray-200 hover:bg-gray-50 cursor-pointer transition-colors">
+              <label className="flex cursor-pointer items-center rounded-xl border border-line p-3 transition-colors hover:bg-fg/5">
                 <input
                   type="radio"
                   name="mode"
                   value="monthly"
                   checked={dateSettings.mode === 'monthly'}
                   onChange={(e) => setDateSettings({ ...dateSettings, mode: e.target.value as DateRangeSettings['mode'] })}
-                  className="w-4 h-4 text-blue-600"
+                  className="h-4 w-4 text-accent focus:ring-ring"
                 />
-                <span className="ml-3 text-sm text-gray-700">月単位で表示</span>
+                <span className="ml-3 text-sm text-fg">月単位で表示</span>
               </label>
 
-              <label className="flex items-center p-3 rounded-xl border border-gray-200 hover:bg-gray-50 cursor-pointer transition-colors">
+              <label className="flex cursor-pointer items-center rounded-xl border border-line p-3 transition-colors hover:bg-fg/5">
                 <input
                   type="radio"
                   name="mode"
                   value="customStart"
                   checked={dateSettings.mode === 'customStart'}
                   onChange={(e) => setDateSettings({ ...dateSettings, mode: e.target.value as DateRangeSettings['mode'] })}
-                  className="w-4 h-4 text-blue-600"
+                  className="h-4 w-4 text-accent focus:ring-ring"
                 />
-                <span className="ml-3 text-sm text-gray-700">指定日を月初として表示</span>
+                <span className="ml-3 text-sm text-fg">指定日を月初として表示</span>
               </label>
 
-              <label className="flex items-center p-3 rounded-xl border border-gray-200 hover:bg-gray-50 cursor-pointer transition-colors">
+              <label className="flex cursor-pointer items-center rounded-xl border border-line p-3 transition-colors hover:bg-fg/5">
                 <input
                   type="radio"
                   name="mode"
                   value="custom"
                   checked={dateSettings.mode === 'custom'}
                   onChange={(e) => setDateSettings({ ...dateSettings, mode: e.target.value as DateRangeSettings['mode'] })}
-                  className="w-4 h-4 text-blue-600"
+                  className="h-4 w-4 text-accent focus:ring-ring"
                 />
-                <span className="ml-3 text-sm text-gray-700">期間を指定して表示</span>
+                <span className="ml-3 text-sm text-fg">期間を指定して表示</span>
               </label>
             </div>
 
             {dateSettings.mode === 'customStart' && (
-              <div className="mt-4 p-4 bg-blue-50 rounded-xl">
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+              <div className="mt-4 rounded-xl bg-accent/[0.06] p-4">
+                <label className="mb-2 block text-sm font-medium text-fg">
                   月初日として扱う日付
                 </label>
                 <select
                   value={tempStartDay}
                   onChange={(e) => setTempStartDay(parseInt(e.target.value))}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+                  className="w-full rounded-lg border border-line bg-card px-3 py-2 text-sm text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
                   {Array.from({ length: 28 }, (_, i) => i + 1).map(day => (
                     <option key={day} value={day}>{day}日</option>
                   ))}
                 </select>
-                <p className="mt-2 text-xs text-gray-600">
+                <p className="mt-2 text-xs text-muted">
                   例：25日を選択すると、25日〜翌月24日を1ヶ月として表示
                 </p>
               </div>
             )}
 
             {dateSettings.mode === 'custom' && (
-              <div className="mt-4 p-4 bg-blue-50 rounded-xl space-y-3">
+              <div className="mt-4 rounded-xl bg-accent/[0.06] p-4 space-y-3">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">開始日</label>
+                  <label className="mb-2 block text-sm font-medium text-fg">開始日</label>
                   <input
                     type="date"
                     value={tempStartDate}
                     onChange={(e) => setTempStartDate(e.target.value)}
                     max={tempEndDate || dayjs().format('YYYY-MM-DD')}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+                    className="w-full rounded-lg border border-line bg-card px-3 py-2 text-sm text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">終了日</label>
+                  <label className="mb-2 block text-sm font-medium text-fg">終了日</label>
                   <input
                     type="date"
                     value={tempEndDate}
                     onChange={(e) => setTempEndDate(e.target.value)}
                     min={tempStartDate}
                     max={dayjs().format('YYYY-MM-DD')}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+                    className="w-full rounded-lg border border-line bg-card px-3 py-2 text-sm text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   />
                 </div>
               </div>
@@ -444,7 +458,7 @@ export default function Settings() {
           <button
             onClick={handleSaveAll}
             disabled={saving}
-            className="w-full py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
+            className="w-full rounded-xl bg-accent py-3 font-medium text-accent-fg shadow-sm transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {saving ? '保存中...' : '設定を保存'}
           </button>

--- a/web/components/GuestGuide.tsx
+++ b/web/components/GuestGuide.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { MessageCircle, Check } from 'lucide-react';
 
 const STEPS: Array<{
   title: string;
@@ -14,7 +15,7 @@ const STEPS: Array<{
     title: 'トークで支出を送信',
     description: (
       <>
-        「<span className="font-semibold text-gray-800">500 ランチ</span>
+        「<span className="font-semibold text-fg">500 ランチ</span>
         」のように金額と内容を送るだけで、カテゴリも自動で分類して記録されます。
         レシート画像の送信にも対応しています。
       </>
@@ -39,58 +40,55 @@ const COMMANDS: Array<{ command: string; description: string }> = [
  */
 export default function GuestGuide({ className = '' }: { className?: string }) {
   return (
-    <div
-      className={`bg-white/80 backdrop-blur-sm rounded-2xl shadow-sm border border-gray-100 p-5 sm:p-6 ${className}`}
-    >
-      <h2 className="text-lg font-semibold text-gray-900 mb-1 flex items-center gap-2">
-        <span className="w-8 h-8 rounded-lg bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-sm">
-          💬
+    <div className={`glass rounded-2xl p-5 shadow-glass sm:p-6 ${className}`}>
+      <h2 className="mb-1 flex items-center gap-2 text-[15px] font-semibold text-fg">
+        <span className="grid h-8 w-8 place-items-center rounded-xl bg-accent text-accent-fg">
+          <MessageCircle className="h-[18px] w-[18px]" strokeWidth={2.2} />
         </span>
         LINE家計簿の使い方
       </h2>
-      <p className="text-xs text-gray-500 mb-5">
+      <p className="mb-5 text-xs text-muted">
         LINEのトークに送るだけで、自動で家計簿がつけられます
       </p>
 
       {/* Steps */}
-      <ol className="space-y-4 mb-6">
+      <ol className="mb-6 space-y-4">
         {STEPS.map((step, index) => (
           <li key={step.title} className="flex gap-3">
-            <span className="flex-shrink-0 w-7 h-7 rounded-full bg-blue-100 text-blue-700 text-sm font-bold flex items-center justify-center">
+            <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-accent/12 text-sm font-bold text-accent">
               {index + 1}
             </span>
             <div className="min-w-0">
-              <p className="text-sm font-semibold text-gray-800">{step.title}</p>
-              <p className="text-xs text-gray-500 mt-0.5 leading-relaxed">{step.description}</p>
+              <p className="text-sm font-semibold text-fg">{step.title}</p>
+              <p className="mt-0.5 text-xs leading-relaxed text-muted">{step.description}</p>
             </div>
           </li>
         ))}
       </ol>
 
-      {/* LINE風トークのイメージ */}
-      <div className="rounded-xl bg-[#8cabd8]/20 p-4 mb-6">
-        <p className="text-[10px] font-medium text-gray-500 mb-2">トークのイメージ</p>
+      {/* トークのイメージ */}
+      <div className="mb-6 rounded-xl bg-fg/[0.03] p-4">
+        <p className="mb-2 text-[10px] font-medium text-muted">トークのイメージ</p>
         <div className="space-y-2">
           <div className="flex justify-end">
-            <span className="inline-block max-w-[80%] bg-[#8de055] text-gray-900 text-xs rounded-2xl rounded-tr-sm px-3 py-2 shadow-sm">
+            <span className="inline-block max-w-[80%] rounded-2xl rounded-tr-sm bg-accent px-3 py-2 text-xs text-accent-fg shadow-sm">
               500 ランチ
             </span>
           </div>
           <div className="flex justify-start">
-            <span className="inline-block max-w-[80%] bg-white text-gray-700 text-xs rounded-2xl rounded-tl-sm px-3 py-2 shadow-sm">
-              ✅ 記録しました
-              <br />
-              🍽️ 食費 / ¥500 / ランチ
+            <span className="inline-flex max-w-[80%] items-center gap-1.5 rounded-2xl rounded-tl-sm bg-card px-3 py-2 text-xs text-fg shadow-sm">
+              <Check className="h-3.5 w-3.5 text-accent" />
+              記録しました：食費 / ¥500 / ランチ
             </span>
           </div>
           <div className="flex justify-end">
-            <span className="inline-block max-w-[80%] bg-[#8de055] text-gray-900 text-xs rounded-2xl rounded-tr-sm px-3 py-2 shadow-sm">
+            <span className="inline-block max-w-[80%] rounded-2xl rounded-tr-sm bg-accent px-3 py-2 text-xs text-accent-fg shadow-sm">
               家計簿
             </span>
           </div>
           <div className="flex justify-start">
-            <span className="inline-block max-w-[80%] bg-white text-gray-700 text-xs rounded-2xl rounded-tl-sm px-3 py-2 shadow-sm">
-              📊 今月の集計と専用リンクをお届けします
+            <span className="inline-block max-w-[80%] rounded-2xl rounded-tl-sm bg-card px-3 py-2 text-xs text-fg shadow-sm">
+              今月の集計と専用リンクをお届けします
             </span>
           </div>
         </div>
@@ -98,17 +96,17 @@ export default function GuestGuide({ className = '' }: { className?: string }) {
 
       {/* Commands */}
       <div>
-        <p className="text-xs font-medium text-gray-600 mb-2">便利なコマンド</p>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <p className="mb-2 text-xs font-medium text-muted">便利なコマンド</p>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           {COMMANDS.map((item) => (
             <div
               key={item.command}
-              className="flex items-center gap-2 bg-gray-50 border border-gray-100 rounded-lg px-3 py-2"
+              className="flex items-center gap-2 rounded-lg border border-line bg-fg/[0.02] px-3 py-2"
             >
-              <code className="flex-shrink-0 text-xs font-semibold text-blue-700 bg-blue-50 border border-blue-100 rounded px-1.5 py-0.5">
+              <code className="flex-shrink-0 rounded border border-accent/20 bg-accent/10 px-1.5 py-0.5 text-xs font-semibold text-accent">
                 {item.command}
               </code>
-              <span className="text-xs text-gray-500 leading-tight">{item.description}</span>
+              <span className="text-xs leading-tight text-muted">{item.description}</span>
             </div>
           ))}
         </div>

--- a/web/components/PreviewModeBanner.tsx
+++ b/web/components/PreviewModeBanner.tsx
@@ -1,27 +1,21 @@
 'use client';
 
-import React from 'react';
+import { Eye } from 'lucide-react';
 
 /**
- * ゲスト（プレビュー）モード時に全ページ共通で表示するバナー。
+ * ゲスト（プレビュー）モード時に表示するバナー。
  * LINEボットから送られるリンクで開くと本人のデータが表示されることを案内する。
  */
 export default function PreviewModeBanner() {
   return (
-    <div className="bg-gradient-to-r from-amber-50 via-orange-50 to-amber-50 border-b border-amber-200">
-      <div className="max-w-4xl mx-auto px-4 py-2.5">
-        <p className="flex items-start justify-center gap-2 text-xs sm:text-sm text-amber-800 leading-relaxed">
-          <span className="text-base leading-none mt-0.5" aria-hidden="true">
-            👀
-          </span>
-          <span>
-            <span className="font-semibold">プレビューモードで表示中</span>
-            <span className="hidden sm:inline"> — </span>
-            <br className="sm:hidden" />
-            LINEボットから送られるリンクで開くと、あなたの家計簿データが表示されます
-          </span>
-        </p>
-      </div>
+    <div className="flex items-start gap-2.5 rounded-2xl border border-amber-500/20 bg-amber-500/[0.08] px-4 py-3 text-amber-700 dark:text-amber-300">
+      <Eye className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={2.1} aria-hidden />
+      <p className="text-xs leading-relaxed sm:text-sm">
+        <span className="font-semibold">プレビューモードで表示中</span>
+        <span className="hidden sm:inline"> — </span>
+        <br className="sm:hidden" />
+        LINEボットから送られるリンクで開くと、あなたの家計簿データが表示されます。
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## 📋 変更内容
UI刷新の **最終フェーズ（Phase 4）**。残る画面・共通パーツを新デザインに統一し、**ユーザー向けUIの絵文字を全廃**しました。

## 🔧 変更種別
- [x] 💄 UI/UX改善

## 主な変更
- **設定 `/settings`**: タブ／月間予算／閾値スライダー／カテゴリ別予算／期間モード／保存をトークン化。タブは lucide（`Wallet`/`CalendarRange`）、カテゴリ別予算に `categoryVisuals` のアイコン＋色。未使用の `emoji` フィールドを削除。メッセージ配色をダーク対応。
- **添付 `/attach`**: ヘッダー（`Paperclip`）、支出概要・完了（`Check`）・差し替え（`RefreshCw`）・ドロップゾーン（`Camera`）・アップロード（`Upload`）をグラス／トークン／lucideへ。
- **`PreviewModeBanner`**: 👀→`Eye`、トークン化（ダーク対応アンバー）。
- **`GuestGuide`**: 💬→`MessageCircle`、✅→`Check`、トーク例の絵文字除去、トークン化。

## 🧪 テスト
- [x] `next build` 成功 / `tsc` 自前コード型エラーなし / `next lint` は既存の `<img>` 警告のみ
- [x] dev: `/settings`・`/attach` HTTP200、**絵文字ゼロ**、致命的エラーなし
- [ ] 実機 SP/PC・ダーク・保存/アップロードの目視（レビュー時）

## ⚠️ 注意事項
- 添付ロジック（href方針・Storageパス）は無改変。
- 残る絵文字は内部 `debug/firebase` ページと `console.log` 文字列のみ（UI非表示）。
- これで UI刷新4フェーズ完了（#93/#94/#95/本PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * レシート添付画面のUIを刷新し、アイコンやカード表示を追加してユーザビリティを向上
  * 設定画面のタブナビゲーションとカテゴリ表示を改善
  * ゲストガイドとプレビューモードバナーのデザインを統一し、視認性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->