### PR TITLE
fix(ui): プレビュー/設定まわりのデザイン統一

### DIFF
--- a/web/app/expenses/page.tsx
+++ b/web/app/expenses/page.tsx
@@ -698,40 +698,6 @@ function ExpensesPageContent() {
           </div>
         </div>
 
-        {/* Individual Person Totals */}
-        {/* {sortedPersonTotals.length > 0 && (
-          <div className="bg-white/90 backdrop-blur-sm rounded-xl shadow-lg border border-gray-200 p-4 mb-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-              👥 個人別合計
-            </h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-              {sortedPersonTotals.map(([personName, total]) => (
-                <div
-                  key={personName}
-                  className="bg-gradient-to-r from-green-50 to-blue-50 rounded-lg p-4 border border-green-200"
-                >
-                  <div className="text-center">
-                    <div className="text-sm font-medium text-gray-700 mb-1">
-                      {personName}
-                    </div>
-                    <div className="text-xl font-bold text-green-600">
-                      ¥{total.toLocaleString()}
-                    </div>
-                    <div className="text-xs text-gray-500">
-                      {
-                        filteredExpenses.filter(
-                          (e) => (e.userDisplayName || "個人") === personName
-                        ).length
-                      }
-                      件
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )} */}
-
         {loading ? (
           <div className="py-16 text-center">
             <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-accent border-t-transparent" />
@@ -942,7 +908,7 @@ function ExpensesPageContent() {
                           name="includeInTotal"
                           checked={editForm.includeInTotal}
                           onChange={handleEditCheckboxChange}
-                          className="h-4 w-4 rounded border-line text-accent focus:ring-ring"
+                          className="h-4 w-4 rounded border-line accent-accent"
                         />
                         <label className="ml-3 text-sm font-medium text-fg">
                           合計に含める

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -296,7 +296,7 @@ export default function Settings() {
                   step="5"
                   value={budgetConfig.alertThreshold}
                   onChange={(e) => setBudgetConfig(prev => ({ ...prev, alertThreshold: parseInt(e.target.value) }))}
-                  className="flex-1"
+                  className="h-2 flex-1 cursor-pointer accent-accent"
                 />
                 <span className="w-14 text-center font-semibold text-fg">
                   {budgetConfig.alertThreshold}%
@@ -370,7 +370,7 @@ export default function Settings() {
                   value="monthly"
                   checked={dateSettings.mode === 'monthly'}
                   onChange={(e) => setDateSettings({ ...dateSettings, mode: e.target.value as DateRangeSettings['mode'] })}
-                  className="h-4 w-4 text-accent focus:ring-ring"
+                  className="h-4 w-4 accent-accent"
                 />
                 <span className="ml-3 text-sm text-fg">月単位で表示</span>
               </label>
@@ -382,7 +382,7 @@ export default function Settings() {
                   value="customStart"
                   checked={dateSettings.mode === 'customStart'}
                   onChange={(e) => setDateSettings({ ...dateSettings, mode: e.target.value as DateRangeSettings['mode'] })}
-                  className="h-4 w-4 text-accent focus:ring-ring"
+                  className="h-4 w-4 accent-accent"
                 />
                 <span className="ml-3 text-sm text-fg">指定日を月初として表示</span>
               </label>
@@ -394,7 +394,7 @@ export default function Settings() {
                   value="custom"
                   checked={dateSettings.mode === 'custom'}
                   onChange={(e) => setDateSettings({ ...dateSettings, mode: e.target.value as DateRangeSettings['mode'] })}
-                  className="h-4 w-4 text-accent focus:ring-ring"
+                  className="h-4 w-4 accent-accent"
                 />
                 <span className="ml-3 text-sm text-fg">期間を指定して表示</span>
               </label>


### PR DESCRIPTION
## 📋 変更内容
UI刷新後に残っていた**プレビューモード／設定画面の未統一**を解消します。

## 🎯 背景
ネイティブの `range`/`radio`/`checkbox` に `text-accent` を当てていましたが、ネイティブ入力は `accent-color` でしか着色できず、**ブラウザ既定の青のまま**になっていました（特に設定画面で「共通化されていない」見え方）。

## 🔧 修正
- `text-accent` → **`accent-accent`（accent-color）** に変更し、アクセント色（emerald）へ統一
  - 設定: 期間モードのラジオ × 3、予算警告のスライダー
  - 支出一覧: 「合計に含める」チェックボックス
- 支出一覧に残っていた**コメントアウト済みの旧「個人別合計」ブロック**（旧 `bg-white`/`gray`/グラデ＋絵文字 👥）を削除

## 🧪 テスト
- [x] `next build` 成功 / `next lint` エラーなし
- [x] 生成CSSに `.accent-accent{accent-color:rgb(var(--accent)/1)}` を確認
- [ ] 実機でラジオ/スライダー/チェックがアクセント色になることを目視（レビュー時）

🤖 Generated with [Claude Code](https://claude.com/claude-code)