### PR TITLE
fix(ui): /link 無限ロード修正＋/link・privacy・terms のデザイン統一

### DIFF
--- a/web/app/link/LinkClientPage.tsx
+++ b/web/app/link/LinkClientPage.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
+import { Link2, AlertTriangle, CheckCircle2 } from "lucide-react";
 
 export default function LinkClientPage() {
   const searchParams = useSearchParams();
@@ -14,7 +15,7 @@ export default function LinkClientPage() {
   const lineId = searchParams.get("lineId");
 
   const verifyToken = useCallback(async () => {
-    // For LINE ID only auth, we simply verify token and lineId exist
+    // LINE ID only auth: just confirm token & lineId are present.
     if (token && lineId) {
       setTokenValid(true);
     } else {
@@ -24,25 +25,27 @@ export default function LinkClientPage() {
   }, [token, lineId]);
 
   useEffect(() => {
-    if (token && lineId) {
-      // Verify token validity
-      verifyToken();
-    } else {
-      setError("無効なリンクです。");
-    }
-  }, [token, lineId, verifyToken]);
+    // verifyToken handles both valid and invalid cases (always resolves the
+    // loading state), so call it unconditionally to avoid getting stuck.
+    verifyToken();
+  }, [verifyToken]);
 
   const handleLinkConfirm = async () => {
-    // Simple confirmation - no server-side verification needed for LINE ID only auth
     setSuccess(true);
   };
 
+  const Shell = ({ children }: { children: React.ReactNode }) => (
+    <div className="flex min-h-dvh items-center justify-center px-4">
+      <div className="glass w-full max-w-md rounded-2xl p-8 text-center shadow-glass">{children}</div>
+    </div>
+  );
+
   if (tokenValid === null) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="flex min-h-dvh items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600">リンクを確認中...</p>
+          <div className="mx-auto h-9 w-9 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+          <p className="mt-3 text-sm text-muted">リンクを確認中...</p>
         </div>
       </div>
     );
@@ -50,142 +53,63 @@ export default function LinkClientPage() {
 
   if (!tokenValid) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="bg-white p-8 rounded-lg shadow-md max-w-md w-full mx-4">
-          <div className="text-center">
-            <div className="text-red-500 mb-4">
-              <svg
-                className="w-16 h-16 mx-auto"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.866-.833-2.5 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
-                />
-              </svg>
-            </div>
-            <h1 className="text-2xl font-bold text-gray-900 mb-4">
-              無効なリンク
-            </h1>
-            <p className="text-gray-600 mb-6">{error}</p>
-            <p className="text-sm text-gray-500">
-              LINEボットから新しいリンクを取得してください。
-            </p>
-          </div>
-        </div>
-      </div>
+      <Shell>
+        <span className="mx-auto mb-4 grid h-14 w-14 place-items-center rounded-2xl bg-rose-500/12 text-rose-500">
+          <AlertTriangle className="h-7 w-7" />
+        </span>
+        <h1 className="text-lg font-semibold text-fg">無効なリンク</h1>
+        <p className="mt-2 text-sm text-muted">{error}</p>
+        <p className="mt-1 text-xs text-muted">LINEボットから新しいリンクを取得してください。</p>
+      </Shell>
     );
   }
 
   if (success) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="bg-white p-8 rounded-lg shadow-md max-w-md w-full mx-4">
-          <div className="text-center">
-            <div className="text-green-500 mb-4">
-              <svg
-                className="w-16 h-16 mx-auto"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-            </div>
-            <h1 className="text-2xl font-bold text-gray-900 mb-4">
-              連携完了！
-            </h1>
-            <p className="text-gray-600 mb-6">
-              LINEアカウントの連携が完了しました。
-            </p>
-            <p className="text-sm text-gray-500 mb-6">
-              これで、LINEボットからの支出データがWebアプリに表示されます。
-            </p>
-            <a
-              href="/expenses"
-              className="inline-block bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 transition-colors"
-            >
-              支出一覧を見る
-            </a>
-          </div>
-        </div>
-      </div>
+      <Shell>
+        <span className="mx-auto mb-4 grid h-14 w-14 place-items-center rounded-2xl bg-accent/12 text-accent">
+          <CheckCircle2 className="h-7 w-7" />
+        </span>
+        <h1 className="text-lg font-semibold text-fg">連携完了</h1>
+        <p className="mt-2 text-sm text-muted">
+          LINEアカウントの連携が完了しました。LINEボットからの支出データがWebアプリに表示されます。
+        </p>
+        <a
+          href={`/expenses${lineId ? `?lineId=${encodeURIComponent(lineId)}` : ""}`}
+          className="mt-5 inline-flex items-center rounded-lg bg-accent px-5 py-2.5 text-sm font-medium text-accent-fg transition-colors hover:opacity-90"
+        >
+          支出一覧を見る
+        </a>
+      </Shell>
     );
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="bg-white p-8 rounded-lg shadow-md max-w-md w-full mx-4">
-        <div className="text-center">
-          <div className="text-blue-600 mb-4">
-            <svg
-              className="w-16 h-16 mx-auto"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-              />
-            </svg>
-          </div>
-          <h1 className="text-2xl font-bold text-gray-900 mb-4">
-            アカウント連携
-          </h1>
-          <p className="text-gray-600 mb-6">
-            LINEボットとの連携を確認して、支出データをWebアプリで確認できるようにします。
-          </p>
+    <Shell>
+      <span className="mx-auto mb-4 grid h-14 w-14 place-items-center rounded-2xl bg-accent/12 text-accent">
+        <Link2 className="h-7 w-7" strokeWidth={2.1} />
+      </span>
+      <h1 className="text-lg font-semibold text-fg">アカウント連携</h1>
+      <p className="mt-2 text-sm text-muted">
+        LINEボットとの連携を確認して、支出データをWebアプリで確認できるようにします。
+      </p>
 
-          {error && (
-            <div className="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
-              <p className="text-red-800 text-sm">{error}</p>
-            </div>
-          )}
-
-          <button
-            onClick={handleLinkConfirm}
-            disabled={loading}
-            className="w-full bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
-          >
-            {loading ? (
-              <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
-            ) : (
-              <>
-                <svg
-                  className="w-5 h-5 mr-3"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-                  />
-                </svg>
-                連携を確認
-              </>
-            )}
-          </button>
-
-          <p className="text-xs text-gray-500 mt-4">
-            このリンクは15分で期限切れになります。
-          </p>
+      {error && (
+        <div className="mt-4 rounded-xl border border-rose-500/20 bg-rose-500/[0.06] p-3">
+          <p className="text-sm text-rose-600 dark:text-rose-400">{error}</p>
         </div>
-      </div>
-    </div>
+      )}
+
+      <button
+        onClick={handleLinkConfirm}
+        disabled={loading}
+        className="mt-5 flex w-full items-center justify-center gap-2 rounded-lg bg-accent px-5 py-3 text-sm font-medium text-accent-fg transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Link2 className="h-5 w-5" strokeWidth={2.1} />
+        連携を確認
+      </button>
+
+      <p className="mt-4 text-xs text-muted">このリンクは15分で期限切れになります。</p>
+    </Shell>
   );
 }

--- a/web/app/link/page.tsx
+++ b/web/app/link/page.tsx
@@ -4,11 +4,8 @@ import LinkClientPage from './LinkClientPage';
 export default function Page() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600">読み込み中...</p>
-        </div>
+      <div className="flex min-h-dvh items-center justify-center">
+        <div className="h-9 w-9 animate-spin rounded-full border-2 border-accent border-t-transparent" />
       </div>
     }>
       <LinkClientPage />

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -2,13 +2,13 @@
 
 export default function PrivacyPolicy() {
   return (
-    <div className="min-h-screen bg-gray-50 py-12 px-4">
-      <div className="max-w-3xl mx-auto bg-white rounded-lg shadow-lg p-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">プライバシーポリシー</h1>
+    <div className="mx-auto w-full max-w-3xl px-4 py-6 md:px-8 md:py-8">
+      <div className="glass rounded-2xl p-6 shadow-glass md:p-8">
+        <h1 className="mb-6 text-2xl font-bold text-fg">プライバシーポリシー</h1>
 
-        <div className="space-y-6 text-gray-700">
+        <div className="space-y-6 text-muted">
           <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">1. 収集する情報</h2>
+            <h2 className="mb-2 text-base font-semibold text-fg">1. 収集する情報</h2>
             <p>本アプリケーション（LINE家計簿）は、以下の情報を収集します：</p>
             <ul className="list-disc list-inside mt-2 space-y-1">
               <li>LINEアカウント情報（ユーザーID、表示名）</li>
@@ -19,7 +19,7 @@ export default function PrivacyPolicy() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">2. 情報の利用目的</h2>
+            <h2 className="mb-2 text-base font-semibold text-fg">2. 情報の利用目的</h2>
             <p>収集した情報は以下の目的で利用します：</p>
             <ul className="list-disc list-inside mt-2 space-y-1">
               <li>家計簿機能の提供</li>
@@ -29,7 +29,7 @@ export default function PrivacyPolicy() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">3. 情報の共有</h2>
+            <h2 className="mb-2 text-base font-semibold text-fg">3. 情報の共有</h2>
             <p>お客様の個人情報を第三者に販売、貸与することはありません。ただし、以下の場合を除きます：</p>
             <ul className="list-disc list-inside mt-2 space-y-1">
               <li>お客様の同意がある場合</li>
@@ -38,16 +38,16 @@ export default function PrivacyPolicy() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">4. データの保護</h2>
+            <h2 className="mb-2 text-base font-semibold text-fg">4. データの保護</h2>
             <p>お客様のデータは、Firebase/Google Cloudの安全なインフラストラクチャで保護されています。</p>
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">5. お問い合わせ</h2>
+            <h2 className="mb-2 text-base font-semibold text-fg">5. お問い合わせ</h2>
             <p>プライバシーに関するお問い合わせは、LINEボットを通じてご連絡ください。</p>
           </section>
 
-          <p className="text-sm text-gray-500 mt-8">最終更新日: 2024年1月</p>
+          <p className="mt-8 text-sm text-muted">最終更新日: 2024年1月</p>
         </div>
       </div>
     </div>

--- a/web/app/terms/page.tsx
+++ b/web/app/terms/page.tsx
@@ -2,18 +2,18 @@
 
 export default function TermsOfService() {
   return (
-    <div className="min-h-screen bg-gray-50 py-12 px-4">
-      <div className="max-w-3xl mx-auto bg-white rounded-lg shadow-lg p-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">利用規約</h1>
+    <div className="mx-auto w-full max-w-3xl px-4 py-6 md:px-8 md:py-8">
+      <div className="glass rounded-2xl p-6 shadow-glass md:p-8">
+        <h1 className="mb-6 text-2xl font-bold text-fg">利用規約</h1>
 
-        <div className="space-y-6 text-gray-700">
+        <div className="space-y-6 text-muted">
           <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">1. サービスの概要</h2>
+            <h2 className="mb-2 text-base font-semibold text-fg">1. サービスの概要</h2>
             <p>LINE家計簿（以下「本サービス」）は、LINEを通じて家計管理を行うためのサービスです。</p>
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">2. 利用条件</h2>
+            <h2 className="mb-2 text-base font-semibold text-fg">2. 利用条件</h2>
             <ul className="list-disc list-inside mt-2 space-y-1">
               <li>本サービスの利用にはLINEアカウントが必要です</li>
               <li>利用者は正確な情報を提供する責任があります</li>
@@ -22,7 +22,7 @@ export default function TermsOfService() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">3. 免責事項</h2>
+            <h2 className="mb-2 text-base font-semibold text-fg">3. 免責事項</h2>
             <ul className="list-disc list-inside mt-2 space-y-1">
               <li>本サービスは「現状有姿」で提供されます</li>
               <li>データの損失や誤りについて責任を負いません</li>
@@ -31,21 +31,21 @@ export default function TermsOfService() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">4. 知的財産権</h2>
+            <h2 className="mb-2 text-base font-semibold text-fg">4. 知的財産権</h2>
             <p>本サービスに関するすべての知的財産権は、サービス提供者に帰属します。</p>
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">5. 規約の変更</h2>
+            <h2 className="mb-2 text-base font-semibold text-fg">5. 規約の変更</h2>
             <p>本規約は予告なく変更される場合があります。変更後も本サービスを利用された場合、変更に同意したものとみなします。</p>
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">6. 準拠法</h2>
+            <h2 className="mb-2 text-base font-semibold text-fg">6. 準拠法</h2>
             <p>本規約は日本法に準拠します。</p>
           </section>
 
-          <p className="text-sm text-gray-500 mt-8">最終更新日: 2024年1月</p>
+          <p className="mt-8 text-sm text-muted">最終更新日: 2024年1月</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📋 変更内容
レビュー指摘の**最優先（ロードマップ#1・#2）**に対応。

## 🐛 バグ修正：/link の無限ロード（最優先）
`token`/`lineId` が無い場合に `setError` だけで `setTokenValid(false)` を呼んでおらず、`tokenValid` が `null` のまま「リンクを確認中...」から抜けませんでした。effect で**常に `verifyToken()` を実行**し、無効時は `tokenValid=false` を設定するよう修正。LINE連携の入口のため最優先で対応。

## 💄 デザイン統一
- **/link**: グラス＋トークン＋lucide（`Link2`/`AlertTriangle`/`CheckCircle2`）へ刷新。成功時の `支出一覧へ` 遷移に `lineId` を引き継ぎ。
- **privacy・terms**: 旧 `gray`/`white` UI → `glass` + `bg/fg/muted` トークンへ統一（シェル内表示に合わせコンテナ化）。
- ローディングフォールバックもトークン化。

## 🧪 テスト
- [x] `next build` 成功 / `next lint` エラーなし
- [x] 残存の旧色（gray/white/blue）ゼロを確認
- [x] dev: `/link`・`/privacy`・`/terms` HTTP200、legalは glass 適用・gray=0
- [ ] 実機で `/link`（無効リンク時に「無効なリンク」表示へ抜ける）の目視（レビュー時）

## ⚠️ 注意
残るレビュー項目（支出一覧の情報階層、デスクトップ幅/多カラム化、編集ドロワー、グラフのインサイト追加、プレビュー体験の統一、next.config の型/ESLint無視見直し）は規模が大きいため別途。下記コメントで方針を相談します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)