### PR TITLE
fix(ui): Codex/CodeRabbit指摘の修正（前月比custom・支払者option）

### DIFF
--- a/web/app/expenses/page.tsx
+++ b/web/app/expenses/page.tsx
@@ -1104,44 +1104,42 @@ function ExpensesPageContent() {
                       onChange={handleEditInputChange}
                       className="w-full rounded-lg border border-line bg-card px-4 py-3 text-base text-fg focus:border-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
-                      {availableMembers.length === 0 ? (
-                        (() => {
-                          const fallbackUsers = new Map<string, string>();
+                      {(() => {
+                        // 候補を重複排除で構築し、現在の支払い者と入力者を必ず含める
+                        // （選択中の値に対応する option が消えて意図しない支払い者へ
+                        // 変わってしまうのを防ぐ）。
+                        const map = new Map<string, string>();
+                        if (editingExpenseData?.lineId) {
+                          map.set(
+                            editingExpenseData.lineId,
+                            `${editingExpenseData.userDisplayName || "入力者"}（入力者）`,
+                          );
+                        }
+                        if (availableMembers.length > 0) {
+                          availableMembers.forEach((member) => {
+                            const label =
+                              member.source === "group" ? "（グループメンバー）"
+                              : member.source === "group-history" ? "（このグループ）"
+                              : member.source === "all-history" ? "（他グループ）"
+                              : "";
+                            if (!map.has(member.lineId)) map.set(member.lineId, `${member.displayName}${label}`);
+                          });
+                        } else {
                           expenses.forEach((exp) => {
-                            if (exp.lineId !== editingExpenseData?.lineId && exp.userDisplayName && exp.userDisplayName !== "個人") {
-                              fallbackUsers.set(exp.lineId, exp.userDisplayName);
+                            if (exp.userDisplayName && exp.userDisplayName !== "個人" && !map.has(exp.lineId)) {
+                              map.set(exp.lineId, `${exp.userDisplayName}（支出履歴から）`);
                             }
                           });
-                          return Array.from(fallbackUsers.entries()).map(([lineId, displayName]) => (
-                            <option key={lineId} value={lineId}>
-                              {displayName}（支出履歴から）
-                            </option>
-                          ));
-                        })()
-                      ) : (
-                        availableMembers.map((member) => {
-                          let label = '';
-                          switch (member.source) {
-                            case 'group': label = '（グループメンバー）'; break;
-                            case 'group-history': label = '（このグループ）'; break;
-                            case 'all-history': label = '（他グループ）'; break;
-                            default: label = '';
-                          }
-                          return (
-                            <option key={member.lineId} value={member.lineId}>
-                              {member.displayName} {label}
-                            </option>
-                          );
-                        })
-                      )}
-                      {editForm.payerId &&
-                        editForm.payerId !== editingExpenseData?.lineId &&
-                        !availableMembers.some((member) => member.lineId === editForm.payerId) &&
-                        !expenses.some((exp) => exp.lineId === editForm.payerId) && (
-                          <option key={editForm.payerId} value={editForm.payerId}>
-                            {editForm.payerDisplayName || "不明なユーザー"}
+                        }
+                        if (editForm.payerId && !map.has(editForm.payerId)) {
+                          map.set(editForm.payerId, editForm.payerDisplayName || "不明なユーザー");
+                        }
+                        return Array.from(map.entries()).map(([value, label]) => (
+                          <option key={value} value={value}>
+                            {label}
                           </option>
-                        )}
+                        ));
+                      })()}
                     </select>
                     <p className="mt-1 text-xs text-muted">デフォルトは入力者と同じです</p>
                   </div>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -304,7 +304,12 @@ export default function Dashboard() {
       : null;
 
   const prevTotal = isGuest ? 0 : prevStats?.totalAmount || 0;
-  const momPct = prevTotal > 0 ? Math.round(((totalExpense - prevTotal) / prevTotal) * 100) : null;
+  // 固定のカスタム期間では getEffectiveDateRange が prevDate を無視し、前期間が
+  // 現在と同一になる（＝自分自身と比較して常に0%）。その場合は前月比を出さない。
+  const momPct =
+    dateSettings.mode !== 'custom' && prevTotal > 0
+      ? Math.round(((totalExpense - prevTotal) / prevTotal) * 100)
+      : null;
 
   return (
     <div className="mx-auto w-full max-w-5xl px-4 py-5 md:px-8 md:py-7">


### PR DESCRIPTION
## 📋 変更内容
Codex / CodeRabbit の自動レビュー指摘のうち、**未対応で有効な2件**を修正。

## 🔧 修正
1. **前月比が custom 期間で常に 0%（Codex P2 / #102）**
   - 固定のカスタム期間では `getEffectiveDateRange(prevDate, …)` が `prevDate` を無視し、前期間が現在と同一になる（＝自分自身と比較）。
   - `dateSettings.mode === 'custom'` のときは**前月比を非表示**に。
2. **支払い者 select で現在値の option が消える（CodeRabbit Major / #101）**
   - `!expenses.some(...)`／`!== editingExpenseData.lineId` の条件により、選択中 `payerId` に対応する option が描画されない経路があり、保存で意図しない支払い者に変わるリスク。
   - 候補を **Map で重複排除**して構築し、**「入力者」と「現在の支払い者」を必ず含める**よう変更。

## ℹ️ レビュー指摘の対応状況
- ドロワーのフォーカストラップ/Esc（Codex P2・CodeRabbit）→ 既に **#103 で対応済み**。
- 本PRで上記2件を解消。

## 🧪 テスト
- [x] `next build` 成功 / `tsc`・`next lint` エラーなし
- [ ] 実機: custom期間で前月比が出ない／支払い者に現在値が常に表示される（レビュー時）

🤖 Generated with [Claude Code](https://claude.com/claude-code)