### PR TITLE
feat(ui): レシート操作を編集ボタンの隣に配置

### DIFF
--- a/web/app/expenses/page.tsx
+++ b/web/app/expenses/page.tsx
@@ -898,26 +898,11 @@ function ExpensesPageContent() {
                             合計から除外
                           </span>
                         )}
-                        {expense.receiptUrl ? (
-                          <a
-                            href={expense.receiptUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 rounded-md bg-amber-500/12 px-2 py-0.5 text-xs font-medium text-amber-600 transition-colors hover:bg-amber-500/20 dark:text-amber-400"
-                            title="レシート画像を開く"
-                          >
+                        {expense.receiptUrl && (
+                          <span className="inline-flex items-center gap-1 rounded-md bg-amber-500/12 px-2 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400">
                             <Paperclip className="h-3 w-3" />
-                            レシート
-                          </a>
-                        ) : (
-                          <a
-                            href={`/attach?expenseId=${encodeURIComponent(expense.id)}`}
-                            className="inline-flex items-center gap-1 rounded-md bg-fg/5 px-2 py-0.5 text-xs font-medium text-muted transition-colors hover:bg-fg/10"
-                            title="レシートを添付"
-                          >
-                            <Paperclip className="h-3 w-3" />
-                            添付
-                          </a>
+                            レシートあり
+                          </span>
                         )}
                       </div>
 
@@ -990,6 +975,29 @@ function ExpensesPageContent() {
                           <Pencil className="h-4 w-4" />
                           編集
                         </button>
+
+                        {/* レシート: 編集の隣に並べて発見しやすく */}
+                        {expense.receiptUrl ? (
+                          <a
+                            href={expense.receiptUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex cursor-pointer items-center gap-1.5 rounded-lg bg-amber-500/12 px-3 py-2 text-sm font-medium text-amber-600 transition-colors hover:bg-amber-500/20 dark:text-amber-400"
+                            title="レシート画像を開く"
+                          >
+                            <Paperclip className="h-4 w-4" />
+                            レシート
+                          </a>
+                        ) : (
+                          <a
+                            href={`/attach?expenseId=${encodeURIComponent(expense.id)}`}
+                            className="flex cursor-pointer items-center gap-1.5 rounded-lg border border-line bg-card px-3 py-2 text-sm font-medium text-fg transition-colors hover:bg-fg/5"
+                            title="レシートを添付"
+                          >
+                            <Paperclip className="h-4 w-4" />
+                            レシート添付
+                          </a>
+                        )}
 
                         <button
                           type="button"


### PR DESCRIPTION
## 📋 変更内容
レシート添付ボタンが分かりづらい（タグ内の小さなリンク）とのご指摘に対応し、**操作ボタン列の「編集」の隣**に移動しました。

## 🔧 変更
- 操作ボタン列（合計切替 / 編集 / 削除）の **「編集」の右隣にレシートボタン** を追加。
  - **未添付**: 「レシート添付」ボタン → `/attach?expenseId=…`
  - **添付済**: 「レシート」ボタン（アンバー）→ 画像を別タブで開く
- タグ行は読み取り用の **「レシートあり」インジケータ** のみに（紛らわしい小リンクは廃止）。

## 🧪 テスト
- [x] `next build` 成功 / `tsc`・`next lint` エラーなし
- [ ] 実機: 未添付→「レシート添付」、添付済→「レシート」、タグの「レシートあり」表示（レビュー時）

🤖 Generated with [Claude Code](https://claude.com/claude-code)