### PR TITLE
fix(web): output:export を外し「index.txt」ダウンロード問題を解消

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,22 +1,21 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: 'export',
+  // NOTE: `output: 'export'` was removed. On Vercel the static export produced
+  // RSC flight files (e.g. `index.txt`) that browsers sometimes downloaded
+  // during client navigation ("index.txt" download bug). Vercel runs Next.js
+  // natively, so we let it handle RSC/routing and serverless API routes.
   trailingSlash: true,
   images: {
-    unoptimized: true
+    unoptimized: true,
   },
-  // Skip type checking during build
+  // Skip type checking during build (pre-existing React 19 / recharts typings)
   typescript: {
     ignoreBuildErrors: true,
   },
   // Skip ESLint during build
   eslint: {
     ignoreDuringBuilds: true,
-  },
-  // Exclude API routes from static export
-  outputFileTracingExcludes: {
-    '*': ['./app/api/**/*']
   },
 };
 


### PR DESCRIPTION
## 🐛 症状
ホームに戻る等のクライアント遷移で、たまに **RSC フライトのペイロード（`index.txt`）がダウンロード**され、画面に生のRSCテキスト（`1:"$Sreact.fragment"…`）が表示される。

## 🎯 原因
`next.config.ts` の **`output: 'export'`（静的エクスポート）** が、Vercel の Next.js ネイティブ配信（`.next` 参照）と噛み合わず、RSCセグメント(`.txt`)が誤って配信されていた（既知の不整合）。

## 🔧 対応
- **`output: 'export'` を削除** → Vercel に Next.js をネイティブに動かさせる（RSC/ルーティングを正しく処理、`app/api/*` は serverless 関数化）。
- 不要になった `outputFileTracingExcludes`（api除外）を削除。
- `trailingSlash` / `images.unoptimized` / 型・ESLintのbuild無視は据え置き。

## 🧪 テスト
- [x] `next build` 成功（通常ビルド: ページは静的プリレンダー、`/api/*` は ƒ serverless）
- [ ] **本PRのVercelプレビューで、ホーム⇄各ページ遷移時に `index.txt` ダウンロードが起きないこと**を確認（重要）

## ⚠️ 注意
- 配信形態が「静的エクスポート」→「Vercelネイティブ(Next.js)」に変わる構成変更です。プレビューデプロイで挙動確認のうえマージ推奨。
- `vercel.json` は `outputDirectory: web/.next` で、非エクスポート構成と整合します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)