### PR TITLE
fix(bot): Webhookデプロイをアンブロック（GITHUB_TOKEN除外）＋カテゴリ判定復旧

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -1286,7 +1286,10 @@ export const webhook = onRequest(
     memory: "512MiB", // Increased from 256MiB to handle image processing
     timeoutSeconds: 540, // Increased from 300s to 540s (9 minutes max)
     invoker: "public",
-    secrets: ["LINE_CHANNEL_TOKEN", "LINE_CHANNEL_SECRET", "GEMINI_API_KEY", "GITHUB_TOKEN"],
+    // GITHUB_TOKEN は未登録のためデプロイがブロックされていた。GitHub Issue自動作成は
+    // 未設定でも安全に「未設定」メッセージを返す実装のため、ここでは宣言しない。
+    // （Issue連携を使う場合は GITHUB_TOKEN シークレットを登録のうえ再追加する）
+    secrets: ["LINE_CHANNEL_TOKEN", "LINE_CHANNEL_SECRET", "GEMINI_API_KEY"],
   },
   app
 );


### PR DESCRIPTION
## 📋 変更内容
未登録の `GITHUB_TOKEN` シークレットにより webhook 関数のデプロイがブロックされていた問題を解消し、**カテゴリ自動判定を本番で復旧**させました（再デプロイ実施済み）。

## 🐛 背景
- カテゴリが常に「その他」になる原因は、本番関数が**旧 `gemini-1.5-flash`(404)** を実行していたこと（ソースは #89 で 2.5-flash 済みだが未デプロイ）。
- 再デプロイしようとしたところ、`GITHUB_TOKEN`（#86 のIssue連携が宣言）が**未登録**でデプロイ失敗。

## 🔧 対応（オプションB）
- webhook の `secrets` から `GITHUB_TOKEN` を除外（`createIssueFromFeedback` は未設定でも安全に「未設定」メッセージを返すため無害）。
- **`firebase deploy --only functions:webhook` を実行済み** → gemini-2.5-flash ＋ 拡充キーワード辞書が本番反映。

## ✅ 結果
- 本番でカテゴリ自動判定が復旧（キーワード一致＋Gemini）。

## ⚠️ 注意
- GitHub Issue自動作成機能は無効（「未設定」応答）。使う場合は `firebase functions:secrets:set GITHUB_TOKEN` 後に secrets へ再追加してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub 連携の設定を簡素化しました。GitHub Token が未設定の場合でも、システムが安全に動作するよう改善されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->