### PR TITLE
fix(deploy): Vercelネイティブ一本化で「index.txt」DL問題を解消

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,139 +1,20 @@
 name: Preview Deployment
 
+# プレビューデプロイも Vercel の Git 連携がネイティブに作成する（PR ごとに
+# プレビューURLを発行）。以前の `vercel build` + `vercel deploy --prebuilt` は
+# 非エクスポート構成＋npm workspaces で失敗するため廃止し、本ワークフローは
+# 意図的に no-op（チェックは緑のまま）。
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-env:
-  NODE_VERSION: '20'
+permissions:
+  contents: read
 
 jobs:
   preview-deploy:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      deployments: write
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
-      - name: Check Vercel token
-        id: check-token
-        run: |
-          if [ -z "$VERCEL_TOKEN" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-            echo "::notice::VERCEL_TOKEN is not set, skipping preview deployment"
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout code
-        if: steps.check-token.outputs.skip != 'true'
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        if: steps.check-token.outputs.skip != 'true'
-        uses: actions/setup-node@v5
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Create deployment
-        if: steps.check-token.outputs.skip != 'true'
-        uses: actions/github-script@v8
-        id: deployment
-        with:
-          script: |
-            const deployment = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.payload.pull_request.head.sha,
-              environment: 'preview',
-              auto_merge: false,
-              required_contexts: [],
-              description: `Preview deployment for PR #${context.payload.pull_request.number}`
-            });
-            return deployment.data.id;
-
-      - name: Install Vercel CLI
-        if: steps.check-token.outputs.skip != 'true'
-        run: npm install -g vercel@latest
-
-      - name: Pull Vercel environment
-        if: steps.check-token.outputs.skip != 'true'
-        working-directory: ./web
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build project
-        if: steps.check-token.outputs.skip != 'true'
-        working-directory: ./web
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy to Vercel Preview
-        if: steps.check-token.outputs.skip != 'true'
-        id: deploy
-        working-directory: ./web
-        run: |
-          DEPLOYMENT_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
-          echo "url=${DEPLOYMENT_URL}" >> $GITHUB_OUTPUT
-          echo "Preview deployed to: ${DEPLOYMENT_URL}"
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      - name: Update deployment status
-        if: steps.check-token.outputs.skip != 'true'
-        uses: actions/github-script@v8
-        with:
-          script: |
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: ${{ steps.deployment.outputs.result }},
-              state: 'success',
-              environment_url: '${{ steps.deploy.outputs.url }}',
-              description: 'Deployment successful'
-            });
-
-      - name: Comment PR
-        if: steps.check-token.outputs.skip != 'true'
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const comment = `## 🔍 Preview Deployment Ready!
-            
-            Your preview deployment is available at: ${{ steps.deploy.outputs.url }}
-            
-            | Status | Preview | Updated |
-            |--------|---------|---------|
-            | ✅ Ready | [Visit Preview](${{ steps.deploy.outputs.url }}) | ${new Date().toISOString()} |
-            
-            This preview will be automatically updated with new commits.`;
-            
-            // Find and update existing comment or create new one
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number
-            });
-            
-            const botComment = comments.find(comment => 
-              comment.user.type === 'Bot' && 
-              comment.body.includes('Preview Deployment Ready')
-            );
-            
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: comment
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: comment
-              });
-            }
+      - name: Handled by Vercel Git integration
+        run: echo "Preview deploys are handled natively by the Vercel Git integration. This workflow is intentionally a no-op."

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,5 +1,11 @@
 name: Vercel Deployment
 
+# Vercel へのデプロイは Vercel の Git 連携（GitHub App）がネイティブに実行する。
+# 以前はここで `vercel build` + `vercel deploy --prebuilt` を ./web 配下で実行して
+# いたが、npm workspaces のホイストにより非エクスポートの Next サーバランタイムを
+# 同梱できず失敗していた（server.runtime.prod.js ENOENT）。
+# Git 連携に一本化したため、本ワークフローは意図的に no-op（チェックは緑のまま）。
+
 on:
   push:
     branches:
@@ -9,130 +15,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-env:
-  NODE_VERSION: '20'
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   deploy:
     name: Deploy to Vercel
     runs-on: ubuntu-latest
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
     steps:
-    - name: Check Vercel token
-      id: check-token
-      run: |
-        if [ -z "$VERCEL_TOKEN" ]; then
-          echo "skip=true" >> $GITHUB_OUTPUT
-          echo "::notice::VERCEL_TOKEN is not set, skipping Vercel deployment"
-        else
-          echo "skip=false" >> $GITHUB_OUTPUT
-        fi
-
-    - name: Checkout code
-      if: steps.check-token.outputs.skip != 'true'
-      uses: actions/checkout@v4
-
-    - name: Setup Node.js
-      if: steps.check-token.outputs.skip != 'true'
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-        cache: 'npm'
-
-    - name: Install Vercel CLI
-      if: steps.check-token.outputs.skip != 'true'
-      run: npm install -g vercel@latest
-
-    - name: Determine environment
-      if: steps.check-token.outputs.skip != 'true'
-      id: env
-      run: |
-        if [[ "${{ github.ref }}" == "refs/heads/master" || "${{ github.ref }}" == "refs/heads/main" ]]; then
-          echo "environment=production" >> $GITHUB_OUTPUT
-          echo "prod_flag=--prod" >> $GITHUB_OUTPUT
-        else
-          echo "environment=preview" >> $GITHUB_OUTPUT
-          echo "prod_flag=" >> $GITHUB_OUTPUT
-        fi
-
-    - name: Pull Vercel Environment Information
-      if: steps.check-token.outputs.skip != 'true'
-      run: vercel pull --yes --environment=${{ steps.env.outputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}
-      working-directory: ./web
-
-    - name: Build Project Artifacts
-      if: steps.check-token.outputs.skip != 'true'
-      run: vercel build ${{ steps.env.outputs.prod_flag }} --token=${{ secrets.VERCEL_TOKEN }}
-      working-directory: ./web
-
-    - name: Deploy Project Artifacts to Vercel
-      if: steps.check-token.outputs.skip != 'true'
-      id: deploy
-      run: |
-        if [[ "${{ github.ref }}" == "refs/heads/master" || "${{ github.ref }}" == "refs/heads/main" ]]; then
-          OUTPUT=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
-        else
-          OUTPUT=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
-        fi
-        echo "url=$OUTPUT" >> $GITHUB_OUTPUT
-        echo "🚀 Deployed to: $OUTPUT"
-      working-directory: ./web
-
-    - name: Comment on PR
-      if: github.event_name == 'pull_request' && steps.check-token.outputs.skip != 'true'
-      uses: actions/github-script@v7
-      env:
-        DEPLOY_URL: ${{ steps.deploy.outputs.url }}
-        BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-        GIT_REF: ${{ github.ref }}
-      with:
-        script: |
-          const url = process.env.DEPLOY_URL || '';
-          const branchName = process.env.BRANCH_NAME || 'unknown';
-          const gitRef = process.env.GIT_REF || '';
-          const environment = gitRef === 'refs/heads/develop' ? 'Development' : 'Preview';
-
-          // Find existing comment
-          const { data: comments } = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-          });
-
-          const botComment = comments.find(comment =>
-            comment.user.type === 'Bot' && comment.body.includes('Vercel Preview URL')
-          );
-
-          const body = `### 🔗 Vercel ${environment} URL
-
-          🚀 **Deployment Status:** ✅ Success
-          🌐 **URL:** ${url}
-          📦 **Branch:** \`${branchName}\`
-          🕐 **Deployed at:** ${new Date().toISOString()}
-
-          ---
-          _This comment is automatically updated on each deployment._`;
-
-          if (botComment) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: botComment.id,
-              body
-            });
-          } else {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body
-            });
-          }
+      - name: Handled by Vercel Git integration
+        run: echo "Vercel deploys are handled natively by the Vercel Git integration. This workflow is intentionally a no-op."

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,22 +1,21 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: 'export',
+  // `output: 'export'` removed: the static export produced RSC flight files
+  // (e.g. `index.txt`) that browsers sometimes downloaded during client
+  // navigation. Vercel builds/serves Next.js natively (via Git integration),
+  // which handles RSC and serverless API routes correctly.
   trailingSlash: true,
   images: {
-    unoptimized: true
+    unoptimized: true,
   },
-  // Skip type checking during build
+  // Skip type checking during build (pre-existing React 19 / recharts typings)
   typescript: {
     ignoreBuildErrors: true,
   },
   // Skip ESLint during build
   eslint: {
     ignoreDuringBuilds: true,
-  },
-  // Exclude API routes from static export
-  outputFileTracingExcludes: {
-    '*': ['./app/api/**/*']
   },
 };
 


### PR DESCRIPTION
## 🐛 対象
クライアント遷移時に RSC ペイロード（`index.txt`）がダウンロードされる問題。

## 🎯 原因
`output:'export'`（静的エクスポート）が Vercel のNext.jsネイティブ配信と噛み合わず、RSCセグメント(.txt)が誤って配信されていた。さらに GH Actions の `vercel deploy --prebuilt` が、`./web` 配下実行＋npm workspaces ホイストで Next サーバランタイムを同梱できず失敗していた（#107 の `server.runtime.prod.js ENOENT`）。

## 🔧 対応
- **`output:'export'` を撤廃**（`outputFileTracingExcludes` も削除）→ Vercel が Next.js をネイティブにビルド/配信、RSC正常化。
- **`vercel-deploy.yml` / `preview.yml` を no-op 化**（チェック名「Deploy to Vercel」「preview-deploy」は緑維持）。デプロイは **Vercel の Git 連携**（確認済み・自動デプロイ）に一本化。
- `ci-cd.yml` の `deploy-web` は master push 限定＋native `vercel --prod` のため据え置き。

## 🧪 検証（重要）
- [x] `next build`（非エクスポート）成功
- [ ] **本PRの Vercel プレビュー（Git連携）で、ホーム⇄各ページ遷移時に `index.txt` DL が起きず、表示・RSCが正常**であることを確認 → 問題なければマージ（マージで本番もネイティブ配信に）。

## ⚠️ 注意
- 万一プレビューが正しく出ない場合、Vercelダッシュボードの **Root Directory = `web`** 設定が必要な可能性があります（その場合はご連絡ください）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * デプロイメントプロセスを Vercel の Git 連携に統合し、自動化を改善しました。
  * ビルド設定を最適化し、サーバー側の処理を有効にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->