### PR TITLE
fix(bot): サマリー見出しの contextText 修正（「の家計簿」回避）

### DIFF
--- a/bot/src/line/flexMessage.ts
+++ b/bot/src/line/flexMessage.ts
@@ -588,7 +588,7 @@ export function buildExpenseSummaryFlexMessage(info: ExpenseSummaryInfo): FlexMe
     categoryTotals,
   } = info;
 
-  const contextText = isGroupContext ? '' : '';
+  const contextText = isGroupContext ? 'グループ' : 'あなた';
   const pendingCount = monthlyCount - monthlyIncludedCount;
 
   // プログレスバーの計算（予算13.6万円に対する割合）
@@ -834,7 +834,7 @@ export function buildEmptyExpenseSummaryFlexMessage(
   isGroupContext: boolean,
   webAppUrl: string
 ): FlexMessage {
-  const contextText = isGroupContext ? '' : '';
+  const contextText = isGroupContext ? 'グループ' : 'あなた';
 
   const bubble: FlexBubble = {
     type: 'bubble',


### PR DESCRIPTION
## 🐛 内容
脱絵文字PR（#113）の一括除去で `contextText` が **両分岐とも空文字**（`isGroupContext ? '' : ''`）になり、サマリー見出しが「**の家計簿**」と不自然に表示されていました（元は絵文字スロットだった箇所）。

## 🔧 修正
`bot/src/line/flexMessage.ts` の 591/837 行を
`isGroupContext ? 'グループ' : 'あなた'` に修正。
→ 見出し（678/848/927 で使用）が「**グループの家計簿**」/「**あなたの家計簿**」に。

## 🧪 テスト
- [x] `bot` ビルド成功 / webhook 再デプロイ済み
- [ ] LINEで「家計簿」送信→見出しが自然な表記（確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)