### PR TITLE
fix(web): 支払者集計の整合化＋旧予算キーの実支出マッピング

### DIFF
--- a/web/app/expenses/page.tsx
+++ b/web/app/expenses/page.tsx
@@ -480,25 +480,27 @@ function ExpensesPageContent() {
     return Array.from(set);
   })();
 
-  // Calculate individual person totals based on payer
-  const personTotals = filteredExpenses.reduce((acc, expense) => {
-    // 支払い者ベースで集計
+  // 支払い者名の解決ルール（金額/件数/チップ表示で共通利用）。
+  // - クレジットカード通知（Gmail自動取得）由来は「クレジットカード」にまとめる
+  // - payerDisplayName を最優先、不明系は支出履歴から表示名を補完
+  const resolvePayerName = (expense: Expense): string => {
+    if (expense.inputSource === 'gmail_auto') {
+      return 'クレジットカード';
+    }
     const payerId = expense.payerId || expense.lineId;
-    // payerDisplayNameを最優先で使用（userDisplayNameは使わない）
     let payerName = expense.payerDisplayName || expense.userDisplayName || "個人";
-
-    // payerDisplayNameが「メンバー」「Unknown_」「User_」「個人」の場合、支出履歴から正しい名前を取得
     if (payerName === 'メンバー' || payerName === '個人' || payerName.startsWith('Unknown_') || payerName.startsWith('User_')) {
       const historicalUser = allHistoricalUsers.find(u => u.lineId === payerId);
       if (historicalUser) {
         payerName = historicalUser.displayName;
       }
     }
+    return payerName;
+  };
 
-    // クレジットカード通知（Gmail自動取得）由来は「クレジットカード」としてまとめる
-    if (expense.inputSource === 'gmail_auto') {
-      payerName = 'クレジットカード';
-    }
+  // Calculate individual person totals based on payer
+  const personTotals = filteredExpenses.reduce((acc, expense) => {
+    const payerName = resolvePayerName(expense);
 
     // 承認済みの項目のみ合計に含める
     if (expense.includeInTotal) {
@@ -703,15 +705,9 @@ function ExpensesPageContent() {
                         <div className="text-lg font-bold tabular-nums text-accent">¥{total.toLocaleString()}</div>
                         <div className="text-xs text-muted">
                           {
-                            filteredExpenses.filter((e) => {
-                              const payerId = e.payerId || e.lineId;
-                              let expensePayerName = e.payerDisplayName || e.userDisplayName || "個人";
-                              if (expensePayerName === 'メンバー' || expensePayerName === '個人' || expensePayerName.startsWith('Unknown_') || expensePayerName.startsWith('User_')) {
-                                const historicalUser = allHistoricalUsers.find(u => u.lineId === payerId);
-                                if (historicalUser) { expensePayerName = historicalUser.displayName; }
-                              }
-                              return expensePayerName === personName;
-                            }).length
+                            filteredExpenses.filter(
+                              (e) => resolvePayerName(e) === personName
+                            ).length
                           }
                           件
                         </div>
@@ -868,24 +864,10 @@ function ExpensesPageContent() {
                             </span>
                           )}
                         {(() => {
-                          // 支払い者の名前を取得（payerDisplayNameを最優先）
-                          const payerId = expense.payerId || expense.lineId;
-                          let payerName = expense.payerDisplayName || expense.userDisplayName || "個人";
+                          // 支払い者の名前を共通ルールで解決（金額/件数集計と一致させる）
                           const isDefaultPayer = !expense.payerId || expense.payerId === expense.lineId;
-
-                          // payerDisplayNameが「メンバー」「Unknown_」「User_」「個人」の場合、支出履歴から正しい名前を取得
-                          if (payerName === 'メンバー' || payerName === '個人' || payerName.startsWith('Unknown_') || payerName.startsWith('User_')) {
-                            const historicalUser = allHistoricalUsers.find(u => u.lineId === payerId);
-                            if (historicalUser) {
-                              payerName = historicalUser.displayName;
-                            }
-                          }
-
-                          // クレジットカード通知（Gmail自動取得）由来は明示的に表示
                           const isCardSource = expense.inputSource === 'gmail_auto';
-                          if (isCardSource) {
-                            payerName = 'クレジットカード';
-                          }
+                          const payerName = resolvePayerName(expense);
 
                           return payerName !== "個人" && (
                             <span className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium ${

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -50,7 +50,15 @@ const budgetToExpenseCategory: Record<string, string[]> = {
 };
 
 function getActualSpending(budgetCategory: string, categoryTotals: Record<string, number>): number {
-  const mapped = budgetToExpenseCategory[budgetCategory] || [budgetCategory];
+  let mapped = budgetToExpenseCategory[budgetCategory];
+  if (!mapped) {
+    // 旧予算キー（例: 娯楽費・医療費）を逆引きして正準キーに解決する。
+    // 正準キーへ統一する以前に保存された予算でも実支出と突き合うようにする。
+    const canonical = Object.keys(budgetToExpenseCategory).find((key) =>
+      budgetToExpenseCategory[key].includes(budgetCategory)
+    );
+    mapped = canonical ? budgetToExpenseCategory[canonical] : [budgetCategory];
+  }
   return mapped.reduce((sum, cat) => sum + (categoryTotals[cat] || 0), 0);
 }
 


### PR DESCRIPTION
## Summary
コードレビュー指摘（支払者集計の不整合・旧予算キーの実支出マッピング欠落）を修正します。

## Changes
- **支払者名の解決を `resolvePayerName()` に共通化**し、①金額集計（personTotals）②件数集計③明細の支払者チップで同一ルールを適用。これまで**件数集計が `gmail_auto`→「クレジットカード」の変換を欠いており**、クレジットカード枠が金額は出るのに「0件」になっていた不整合を解消。
- **`getActualSpending()` に旧予算キーの逆引きフォールバック**を追加。正準化前に保存された予算キー（`娯楽費`/`医療費` 等）でも、`budgetToExpenseCategory` のエイリアス値から正準キーを逆引きして実支出と突き合うようにし、カテゴリ別予算の進捗が0表示になる問題を解消。

## 指摘のうち対応不要だったもの
- `allCategories` の rules-of-hooks 指摘 → #116 で既に **純粋計算（IIFE）化済み**で、Hookではないため違反は発生しない。

## Test Plan
- [x] `npm run build`（web）通過、`next lint` 警告/エラーなし
- [ ] クレジットカード枠の金額と件数が一致して表示される
- [ ] 旧名で保存済みのカテゴリ別予算でも実支出が反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)