### PR TITLE
feat(web): SP遷移をSPA化（遷移アニメ＋データキャッシュ）

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -21,6 +21,7 @@ import { getCategoryVisual } from '../lib/categoryVisuals';
 import PreviewModeBanner from '../components/PreviewModeBanner';
 import GuestGuide from '../components/GuestGuide';
 import { getSampleStats } from '../lib/sampleData';
+import { getCached, setCached, hasCached } from '../lib/swrCache';
 import dayjs from 'dayjs';
 import { db } from '../lib/firebase';
 
@@ -211,9 +212,13 @@ function BudgetProgress({ stats, budgetConfig }: { stats: ExpenseStats | null; b
 /* ------------------------------- Page ----------------------------------- */
 export default function Dashboard() {
   const { user, loading: authLoading } = useLineAuth();
+  const dsCacheKey = user?.uid ? `dateSettings:${user.uid}` : '';
   const [currentDate, setCurrentDate] = useState(dayjs());
-  const [dateSettings, setDateSettings] = useState<DateRangeSettings>({ mode: 'monthly' });
-  const [settingsLoading, setSettingsLoading] = useState(true);
+  const [dateSettings, setDateSettings] = useState<DateRangeSettings>(
+    () => (dsCacheKey && getCached<DateRangeSettings>(dsCacheKey)) || { mode: 'monthly' }
+  );
+  // 設定がキャッシュ済みなら全画面スピナーを出さない（再訪時の点滅防止）
+  const [settingsLoading, setSettingsLoading] = useState(() => !(dsCacheKey && hasCached(dsCacheKey)));
   const [firebaseError, setFirebaseError] = useState(false);
 
   const { config: budgetConfig, loading: budgetLoading, error: budgetError, refetch: refetchBudget } =
@@ -231,12 +236,22 @@ export default function Dashboard() {
         setSettingsLoading(false);
         return;
       }
-      try {
+      const key = `dateSettings:${user.uid}`;
+      const cached = getCached<DateRangeSettings>(key);
+      // キャッシュがあれば即表示して裏で再取得（スピナーを出さない）
+      if (cached) {
+        setDateSettings(cached);
+        setSettingsLoading(false);
+      } else {
         setSettingsLoading(true);
-        setDateSettings(await getDateRangeSettings(user.uid));
+      }
+      try {
+        const fresh = await getDateRangeSettings(user.uid);
+        setCached(key, fresh);
+        setDateSettings(fresh);
       } catch (e) {
         console.error('Failed to load date settings:', e);
-        setDateSettings({ mode: 'monthly' });
+        if (!cached) setDateSettings({ mode: 'monthly' });
       } finally {
         setSettingsLoading(false);
       }

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -10,6 +10,7 @@ import { db } from '../../lib/firebase';
 import PreviewModeBanner from '../../components/PreviewModeBanner';
 import { getCategoryVisual } from '../../lib/categoryVisuals';
 import { CANONICAL_CATEGORIES } from '../../lib/categoryNormalization';
+import { getCached, setCached } from '../../lib/swrCache';
 import dayjs from 'dayjs';
 
 // 予算設定インターフェース
@@ -56,19 +57,25 @@ function normalizeBudgetConfig(data: unknown): BudgetConfig {
 export default function Settings() {
   const { user, loading: authLoading, getUrlWithLineId } = useLineAuth();
 
+  // 再訪時の全画面スピナーを避けるためのキャッシュキー
+  const dsCacheKey = user?.uid ? `dateSettings:${user.uid}` : '';
+  const sbCacheKey = user?.uid ? `settingsBudget:${user.uid}` : '';
+  const cachedDate = dsCacheKey ? getCached<DateRangeSettings>(dsCacheKey) : undefined;
+  const cachedBudget = sbCacheKey ? getCached<BudgetConfig>(sbCacheKey) : undefined;
+
   // 期間設定
-  const [dateSettings, setDateSettings] = useState<DateRangeSettings>(DEFAULT_SETTINGS);
-  const [tempStartDate, setTempStartDate] = useState('');
-  const [tempEndDate, setTempEndDate] = useState('');
-  const [tempStartDay, setTempStartDay] = useState(1);
+  const [dateSettings, setDateSettings] = useState<DateRangeSettings>(cachedDate || DEFAULT_SETTINGS);
+  const [tempStartDate, setTempStartDate] = useState(cachedDate?.startDate || '');
+  const [tempEndDate, setTempEndDate] = useState(cachedDate?.endDate || '');
+  const [tempStartDay, setTempStartDay] = useState(cachedDate?.customStartDay || 1);
 
   // 予算設定
-  const [budgetConfig, setBudgetConfig] = useState<BudgetConfig>(defaultBudgetConfig);
-  const [budgetHasLoaded, setBudgetHasLoaded] = useState(false);
+  const [budgetConfig, setBudgetConfig] = useState<BudgetConfig>(cachedBudget || defaultBudgetConfig);
+  const [budgetHasLoaded, setBudgetHasLoaded] = useState(!!cachedBudget);
   const [budgetLoadError, setBudgetLoadError] = useState(false);
 
-  // 共通
-  const [loading, setLoading] = useState(true);
+  // 共通（date・budget ともキャッシュ済みならスピナーを出さない）
+  const [loading, setLoading] = useState(!(cachedDate && cachedBudget));
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [activeTab, setActiveTab] = useState<'period' | 'budget'>('budget');
@@ -80,12 +87,15 @@ export default function Settings() {
         return;
       }
 
+      // キャッシュがあれば即表示し、裏で再取得（スピナーを出さない）
+      const hadCache = !!(getCached(`dateSettings:${user.uid}`) && getCached(`settingsBudget:${user.uid}`));
       try {
-        setLoading(true);
+        if (!hadCache) setLoading(true);
 
         // 期間設定の読み込み
         await migrateLocalToFirestore(user.uid);
         const loadedDateSettings = await getDateRangeSettings(user.uid);
+        setCached(`dateSettings:${user.uid}`, loadedDateSettings);
         setDateSettings(loadedDateSettings);
         setTempStartDate(loadedDateSettings.startDate || '');
         setTempEndDate(loadedDateSettings.endDate || '');
@@ -97,6 +107,7 @@ export default function Settings() {
           const docSnap = await getDoc(docRef);
           if (docSnap.exists()) {
             const normalizedConfig = normalizeBudgetConfig(docSnap.data());
+            setCached(`settingsBudget:${user.uid}`, normalizedConfig);
             setBudgetConfig(normalizedConfig);
           }
           setBudgetHasLoaded(true);
@@ -129,6 +140,8 @@ export default function Settings() {
 
     await saveDateRangeSettings(user.uid, newSettings);
     setDateSettings(newSettings);
+    // 保存後はキャッシュも更新（ホーム/再訪時に最新を即表示）
+    setCached(`dateSettings:${user.uid}`, newSettings);
   };
 
   const saveBudgetSettingsHandler = async () => {
@@ -149,6 +162,9 @@ export default function Settings() {
       ...budgetConfig,
       updatedAt: new Date(),
     });
+    // 保存後はキャッシュも更新（settings再訪・ホームの予算表示に即反映）
+    setCached(`settingsBudget:${user.uid}`, budgetConfig);
+    setCached(`budget:${user.uid}`, budgetConfig);
   };
 
   const handleSaveAll = async () => {

--- a/web/components/layout/AppShell.tsx
+++ b/web/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { Sidebar } from './Sidebar';
 import { BottomTabBar } from './BottomTabBar';
 import { TopBar } from './TopBar';
@@ -12,6 +13,7 @@ const BARE_ROUTES = ['/attach', '/link', '/debug'];
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() || '/';
+  const reduceMotion = useReducedMotion();
   const [lineId, setLineId] = useState<string | null>(null);
 
   // Read lineId after mount to keep SSR/first-render markup stable (no hydration mismatch).
@@ -42,8 +44,21 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <div className="md:pl-60">
         <TopBar hrefFor={hrefFor} />
         {/* Pages own their inner container/padding; shell adds offset for the
-            fixed bottom tab on mobile so content never hides behind it. */}
-        <main className="pb-24 md:pb-0">{children}</main>
+            fixed bottom tab on mobile so content never hides behind it.
+            SPA らしい遷移のため、ルート切替を軽いフェード＋スライドで繋ぐ。 */}
+        <main className="pb-24 md:pb-0">
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={pathname}
+              initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={reduceMotion ? undefined : { opacity: 0, y: -6 }}
+              transition={{ duration: 0.18, ease: 'easeOut' }}
+            >
+              {children}
+            </motion.div>
+          </AnimatePresence>
+        </main>
       </div>
 
       <BottomTabBar pathname={pathname} hrefFor={hrefFor} />

--- a/web/lib/hooks.ts
+++ b/web/lib/hooks.ts
@@ -16,6 +16,7 @@ import {
 import { db, getFirebaseStatus, ensureFirebaseInitialized } from './firebase';
 import dayjs from 'dayjs';
 import { normalizeCategoryName } from './categoryNormalization';
+import { getCached, setCached, hasCached } from './swrCache';
 
 // Firestore document data shape for expenses (avoids explicit any)
 export type FirestoreExpenseData = Partial<Expense> & { category?: string };
@@ -193,54 +194,42 @@ const waitForFirebase = async (maxWaitMs: number = 5000, signal?: AbortSignal): 
   return checkFirebaseConnection();
 };
 
+// 認証はURL(lineId)から同期的に導出でき、アプリ内ナビでは値が変わらない。
+// 解決結果をモジュールに保持し、ページ再マウント時はそこから即時復元することで、
+// タブ切替のたびに全画面スピナーが1フレーム出る「リロード感」をなくす。
+// 初回ロードは null/loading=true で始まる（SSRと一致しハイドレーション不整合を避ける）。
+let cachedLineAuth: { uid: string; isAnonymous: boolean } | null = null;
+
+function getLineIdFromUrl(): string | null {
+  if (typeof window === 'undefined') return null;
+  const urlParams = new URLSearchParams(window.location.search);
+  let lineId = urlParams.get('lineId');
+  if (!lineId && window.location.hash) {
+    const hashParams = new URLSearchParams(window.location.hash.replace('#', ''));
+    lineId = hashParams.get('lineId');
+  }
+  if (!lineId) {
+    const match = window.location.href.match(/[?&]lineId=([^&]+)/);
+    if (match) {
+      lineId = decodeURIComponent(match[1]);
+    }
+  }
+  return lineId;
+}
+
 export function useLineAuth() {
-  const [user, setUser] = useState<{ uid: string; isAnonymous: boolean } | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [user, setUser] = useState<{ uid: string; isAnonymous: boolean } | null>(() => cachedLineAuth);
+  const [loading, setLoading] = useState(() => cachedLineAuth === null);
 
   useEffect(() => {
-    // LINE IDベースの認証では、URLパラメータからLINE IDを取得
-    // 静的サイトでのクライアントサイドルーティング対応
-    const getLineIdFromUrl = () => {
-      if (typeof window === 'undefined') return null;
-      
-      // Try multiple ways to get the LINE ID
-      const urlParams = new URLSearchParams(window.location.search);
-      let lineId = urlParams.get('lineId');
-      
-      // If not found in search params, try hash
-      if (!lineId && window.location.hash) {
-        const hashParams = new URLSearchParams(window.location.hash.replace('#', ''));
-        lineId = hashParams.get('lineId');
-      }
-      
-      // If still not found, try parsing the full URL
-      if (!lineId) {
-        const match = window.location.href.match(/[?&]lineId=([^&]+)/);
-        if (match) {
-          lineId = decodeURIComponent(match[1]);
-        }
-      }
-      
-      return lineId;
-    };
-    
     const lineId = getLineIdFromUrl();
-    
-    console.log('LINE ID from URL:', lineId);
-    console.log('Current URL:', window.location.href);
-    console.log('Search params:', window.location.search);
-    console.log('Hash:', window.location.hash);
-    
-    if (lineId) {
-      // LINE IDが存在する場合は、それをユーザーIDとして使用
-      console.log('Setting user with LINE ID:', lineId);
-      setUser({ uid: lineId, isAnonymous: false });
-    } else {
-      // LINE IDが存在しない場合はゲストユーザーとして扱う
-      console.log('No LINE ID found, setting guest user');
-      setUser({ uid: 'guest', isAnonymous: true });
-    }
-    
+
+    const resolved = lineId
+      ? { uid: lineId, isAnonymous: false }
+      : { uid: 'guest', isAnonymous: true };
+
+    cachedLineAuth = resolved;
+    setUser(resolved);
     setLoading(false);
   }, []);
 
@@ -249,8 +238,9 @@ export function useLineAuth() {
     const url = new URL(window.location.href);
     url.searchParams.delete('lineId');
     window.history.replaceState({}, '', url.toString());
-    
-    // ゲストユーザーに戻す
+
+    // ゲストユーザーに戻す（モジュールキャッシュも同期）
+    cachedLineAuth = { uid: 'guest', isAnonymous: true };
     setUser({ uid: 'guest', isAnonymous: true });
   };
 
@@ -275,8 +265,9 @@ export function useLineAuth() {
 }
 
 export function useExpenses(userId: string | null, periodDays: number = 50, limitCount: number = 200, customStartDate?: string) {
-  const [expenses, setExpenses] = useState<Expense[]>([]);
-  const [loading, setLoading] = useState(true);
+  const expensesCacheKey = `expenses:${userId}:${periodDays}:${limitCount}:${customStartDate || ''}`;
+  const [expenses, setExpenses] = useState<Expense[]>(() => getCached<Expense[]>(expensesCacheKey) ?? []);
+  const [loading, setLoading] = useState(() => !hasCached(expensesCacheKey));
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -284,6 +275,15 @@ export function useExpenses(userId: string | null, periodDays: number = 50, limi
       setLoading(false);
       setExpenses([]);
       return;
+    }
+
+    // 再訪時はキャッシュを即表示し、裏で再取得（スピナーを出さない）。
+    const cached = getCached<Expense[]>(expensesCacheKey);
+    if (cached) {
+      setExpenses(cached);
+      setLoading(false);
+    } else {
+      setLoading(true);
     }
 
     const fetchExpenses = async () => {
@@ -297,9 +297,8 @@ export function useExpenses(userId: string | null, periodDays: number = 50, limi
       }
 
       try {
-        setLoading(true);
         setError(null);
-        
+
         console.log("データ取得開始 - userId:", userId, "period:", periodDays);
         
         // Firebase接続の再確認
@@ -533,20 +532,24 @@ export function useExpenses(userId: string | null, periodDays: number = 50, limi
           return bTime - aTime; // desc order
         });
         
+        setCached(expensesCacheKey, sortedExpenses);
         setExpenses(sortedExpenses);
         setError(null);
       } catch (err) {
         const errorMessage = handleFirestoreError(err);
         console.error('Error fetching expenses:', err);
         setError(errorMessage);
-        setExpenses([]);
+        // キャッシュがある場合は消さず、前回値を残す（取得失敗でも空にしない）
+        if (!hasCached(expensesCacheKey)) {
+          setExpenses([]);
+        }
       } finally {
         setLoading(false);
       }
     };
 
     fetchExpenses();
-  }, [userId, periodDays, limitCount, customStartDate]);
+  }, [userId, periodDays, limitCount, customStartDate, expensesCacheKey]);
 
   const updateExpense = async (id: string, updates: Partial<Expense>) => {
     if (!checkFirebaseConnection()) {
@@ -573,12 +576,14 @@ export function useExpenses(userId: string | null, periodDays: number = 50, limi
         updatedAt: new Date()
       });
       
-      // Update local state
-      setExpenses(prev => 
-        prev.map(expense => 
+      // Update local state（キャッシュも同期して再訪時の巻き戻りを防ぐ）
+      setExpenses(prev => {
+        const next = prev.map(expense =>
           expense.id === id ? { ...expense, ...normalizedUpdates } : expense
-        )
-      );
+        );
+        setCached(expensesCacheKey, next);
+        return next;
+      });
     } catch (err) {
       const errorMessage = handleFirestoreError(err);
       console.error('Error updating expense:', err);
@@ -598,8 +603,12 @@ export function useExpenses(userId: string | null, periodDays: number = 50, limi
     try {
       await deleteDoc(doc(db, 'expenses', id));
       
-      // Update local state
-      setExpenses(prev => prev.filter(expense => expense.id !== id));
+      // Update local state（キャッシュも同期）
+      setExpenses(prev => {
+        const next = prev.filter(expense => expense.id !== id);
+        setCached(expensesCacheKey, next);
+        return next;
+      });
     } catch (err) {
       const errorMessage = handleFirestoreError(err);
       console.error('Error deleting expense:', err);
@@ -624,14 +633,24 @@ export function useExpenses(userId: string | null, periodDays: number = 50, limi
 }
 
 export function useMonthlyStats(userId: string | null, year: number, month: number, startDay: number = 1, customStartDate?: string, customEndDate?: string) {
-  const [stats, setStats] = useState<ExpenseStats | null>(null);
-  const [loading, setLoading] = useState(true);
+  const statsCacheKey = `stats:${userId}:${customStartDate || ''}:${customEndDate || ''}:${year}:${month}:${startDay}`;
+  const [stats, setStats] = useState<ExpenseStats | null>(() => getCached<ExpenseStats>(statsCacheKey) ?? null);
+  const [loading, setLoading] = useState(() => !hasCached(statsCacheKey));
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!userId || userId === 'guest') {
       setLoading(false);
       return;
+    }
+
+    // 再訪時はキャッシュを即表示し、スピナーを出さずに裏で再取得する。
+    const cached = getCached<ExpenseStats>(statsCacheKey);
+    if (cached) {
+      setStats(cached);
+      setLoading(false);
+    } else {
+      setLoading(true);
     }
 
     const fetchStats = async () => {
@@ -644,9 +663,8 @@ export function useMonthlyStats(userId: string | null, year: number, month: numb
         return;
       }
       try {
-        setLoading(true);
         setError(null);
-        
+
         if (!db) {
           throw new Error('Firestoreデータベースが利用できません');
         }
@@ -757,12 +775,14 @@ export function useMonthlyStats(userId: string | null, year: number, month: numb
           return acc;
         }, {} as Record<string, number>);
         
-        setStats({
+        const nextStats: ExpenseStats = {
           totalAmount,
           expenseCount: includedExpenses.length,
           categoryTotals,
           dailyTotals
-        });
+        };
+        setCached(statsCacheKey, nextStats);
+        setStats(nextStats);
         setError(null);
       } catch (err) {
         const errorMessage = handleFirestoreError(err);
@@ -774,7 +794,7 @@ export function useMonthlyStats(userId: string | null, year: number, month: numb
     };
 
     fetchStats();
-  }, [userId, year, month, startDay, customStartDate, customEndDate]);
+  }, [userId, year, month, startDay, customStartDate, customEndDate, statsCacheKey]);
 
   return { stats, loading, error };
 }
@@ -1207,8 +1227,9 @@ const defaultBudgetConfig: BudgetConfig = {
 
 // Firestoreから予算設定を取得するフック
 export function useBudgetConfig(userId: string | null) {
-  const [config, setConfig] = useState<BudgetConfig | null>(null);
-  const [loading, setLoading] = useState(true);
+  const budgetCacheKey = `budget:${userId}`;
+  const [config, setConfig] = useState<BudgetConfig | null>(() => getCached<BudgetConfig>(budgetCacheKey) ?? null);
+  const [loading, setLoading] = useState(() => !hasCached(budgetCacheKey));
   const [error, setError] = useState<string | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
 
@@ -1217,6 +1238,15 @@ export function useBudgetConfig(userId: string | null) {
       setConfig(defaultBudgetConfig);
       setLoading(false);
       return;
+    }
+
+    // 再訪時はキャッシュを即表示し、裏で再取得する。
+    const cached = getCached<BudgetConfig>(budgetCacheKey);
+    if (cached) {
+      setConfig(cached);
+      setLoading(false);
+    } else {
+      setLoading(true);
     }
 
     const fetchBudgetConfig = async () => {
@@ -1229,7 +1259,6 @@ export function useBudgetConfig(userId: string | null) {
       }
 
       try {
-        setLoading(true);
         setError(null);
 
         if (!db) {
@@ -1239,35 +1268,37 @@ export function useBudgetConfig(userId: string | null) {
         const docRef = doc(db, 'budgetSettings', userId);
         const docSnap = await getDoc(docRef);
 
-        if (docSnap.exists()) {
-          const data = docSnap.data();
-          setConfig({
-            monthlyBudget: typeof data.monthlyBudget === 'number' && data.monthlyBudget > 0
-              ? data.monthlyBudget
-              : defaultBudgetConfig.monthlyBudget,
-            categoryBudgets: data.categoryBudgets && typeof data.categoryBudgets === 'object'
-              ? data.categoryBudgets
-              : {},
-            alertThreshold: typeof data.alertThreshold === 'number'
-              ? data.alertThreshold
-              : defaultBudgetConfig.alertThreshold,
-          });
-        } else {
-          setConfig(defaultBudgetConfig);
-        }
+        const nextConfig: BudgetConfig = docSnap.exists()
+          ? {
+              monthlyBudget: typeof docSnap.data().monthlyBudget === 'number' && docSnap.data().monthlyBudget > 0
+                ? docSnap.data().monthlyBudget
+                : defaultBudgetConfig.monthlyBudget,
+              categoryBudgets: docSnap.data().categoryBudgets && typeof docSnap.data().categoryBudgets === 'object'
+                ? docSnap.data().categoryBudgets
+                : {},
+              alertThreshold: typeof docSnap.data().alertThreshold === 'number'
+                ? docSnap.data().alertThreshold
+                : defaultBudgetConfig.alertThreshold,
+            }
+          : defaultBudgetConfig;
+
+        setCached(budgetCacheKey, nextConfig);
+        setConfig(nextConfig);
         setError(null);
       } catch (err) {
         const errorMessage = handleFirestoreError(err);
         console.error('Error fetching budget config:', err);
         setError(errorMessage);
-        setConfig(defaultBudgetConfig);
+        if (!hasCached(budgetCacheKey)) {
+          setConfig(defaultBudgetConfig);
+        }
       } finally {
         setLoading(false);
       }
     };
 
     fetchBudgetConfig();
-  }, [userId, refreshTrigger]);
+  }, [userId, refreshTrigger, budgetCacheKey]);
 
   // 手動で再取得するための関数
   const refetch = () => {

--- a/web/lib/swrCache.ts
+++ b/web/lib/swrCache.ts
@@ -1,0 +1,31 @@
+// 画面間遷移を「SPAっぽく」するための超軽量メモリキャッシュ。
+// 一度取得したデータをキー単位で保持し、再訪時はキャッシュを即表示しつつ
+// 裏で再取得（stale-while-revalidate）してスピナーの点滅をなくす。
+//
+// 注意:
+// - プロセス内メモリのみ（タブを閉じると消える）。永続化はしない。
+// - 値は浅い参照で保持する。呼び出し側は更新時に新しいオブジェクトを渡すこと。
+
+const store = new Map<string, unknown>();
+
+export function hasCached(key: string): boolean {
+  return store.has(key);
+}
+
+export function getCached<T>(key: string): T | undefined {
+  return store.get(key) as T | undefined;
+}
+
+export function setCached<T>(key: string, value: T): void {
+  store.set(key, value);
+}
+
+export function clearCached(prefix?: string): void {
+  if (!prefix) {
+    store.clear();
+    return;
+  }
+  for (const key of store.keys()) {
+    if (key.startsWith(prefix)) store.delete(key);
+  }
+}


### PR DESCRIPTION
## Summary
SPでホーム/支出/設定を切り替えると「リロードっぽく」感じる問題を改善します。遷移自体は `<Link>` でクライアント遷移済みでしたが、①ページ再マウント毎に認証ローディングの全画面スピナーが1フレーム出る ②各ページが毎回データ取得してスピナーを出す ③遷移アニメが無い、の3点が原因でした。

## Changes
- **`useLineAuth`**: 認証結果（URLのlineId由来）をモジュールに保持し、ページ再マウント時に即時復元。これまで再マウントの度に `loading=true→false` で全画面スピナーが1フレーム出ていた（リロード感の主因）。初回ロードは `null/loading=true` で開始しSSRと一致（ハイドレーション不整合なし）。
- **`lib/swrCache.ts`（新規）**: 超軽量メモリキャッシュ（stale-while-revalidate）。
- **`useMonthlyStats` / `useExpenses` / `useBudgetConfig`**: 再訪時はキャッシュを即表示→裏で再取得。編集/削除はキャッシュも同期。
- **home / settings**: `dateRangeSettings`・予算をキャッシュし、全画面スピナーを抑制。保存時にキャッシュ更新。
- **`AppShell`**: framer-motion でルート切替に軽いフェード＋スライド（`prefers-reduced-motion` 時は無効）。

## Test Plan
- [x] `npm run build`（web）通過、`next lint` 警告/エラーなし
- [ ] SPでタブ切替がスピナー無しで滑らかに繋がる
- [ ] 初回ロード・データ更新後の表示が正しい（キャッシュが古いまま残らない）
- [ ] reduced-motion 設定でアニメが無効

🤖 Generated with [Claude Code](https://claude.com/claude-code)