### PR TITLE
feat(web): レシート画像をアップロード前に圧縮（リサイズ＋再エンコード）

### DIFF
--- a/web/app/attach/page.tsx
+++ b/web/app/attach/page.tsx
@@ -7,6 +7,7 @@ import { doc, getDoc, updateDoc } from "firebase/firestore";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { db, storage, ensureFirebaseInitialized } from "../../lib/firebase";
 import { isSafeImageUrl } from "../../lib/imageUrl";
+import { compressImage } from "../../lib/imageCompress";
 import dayjs from "dayjs";
 
 // Suspense boundary for useSearchParams（ビルドエラー防止）
@@ -127,13 +128,23 @@ function AttachPageContent() {
         throw new Error("Firebaseの初期化に失敗しました。");
       }
 
+      // アップロード前にリサイズ＋JPEG再エンコードで圧縮（容量・帯域の長期削減）
+      const { file: uploadFile, compressed, originalSize, outputSize } =
+        await compressImage(selectedFile);
+      if (compressed) {
+        console.log(
+          `レシート圧縮: ${(originalSize / 1024).toFixed(0)}KB → ${(outputSize / 1024).toFixed(0)}KB ` +
+            `(${Math.round((1 - outputSize / originalSize) * 100)}%削減)`
+        );
+      }
+
       // パス: receipts/{expenseId}/{timestamp}_{filename}
       const timestamp = Date.now();
-      const safeName = selectedFile.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+      const safeName = uploadFile.name.replace(/[^a-zA-Z0-9._-]/g, "_");
       const storageRef = ref(storage, `receipts/${expenseId}/${timestamp}_${safeName}`);
 
-      await uploadBytes(storageRef, selectedFile, {
-        contentType: selectedFile.type,
+      await uploadBytes(storageRef, uploadFile, {
+        contentType: uploadFile.type,
       });
       const downloadUrl = await getDownloadURL(storageRef);
 

--- a/web/lib/imageCompress.ts
+++ b/web/lib/imageCompress.ts
@@ -1,0 +1,127 @@
+// レシート画像をアップロード前にクライアント側でリサイズ＋再エンコードする。
+// 文字が読める品質を保ちつつ、Storage 容量・転送帯域を長期的に削減する目的。
+//
+// 方針:
+// - 長辺を maxEdge までに縮小（拡大はしない）
+// - JPEG で再エンコード（quality 既定 0.72）
+// - 元が十分小さい/画像でない/デコード不能な場合は元ファイルをそのまま返す
+// - EXIF の回転は createImageBitmap の imageOrientation で吸収する
+
+export interface CompressOptions {
+  /** 長辺の最大ピクセル（既定 1600） */
+  maxEdge?: number;
+  /** JPEG 画質 0〜1（既定 0.72） */
+  quality?: number;
+  /** これ以下のサイズ(byte)は圧縮しない（既定 300KB） */
+  skipUnderBytes?: number;
+}
+
+export interface CompressResult {
+  /** アップロードするファイル（圧縮できなければ元ファイル） */
+  file: File;
+  /** 圧縮されたか */
+  compressed: boolean;
+  /** 元サイズ(byte) */
+  originalSize: number;
+  /** 出力サイズ(byte) */
+  outputSize: number;
+}
+
+async function decodeImage(file: File): Promise<ImageBitmap | null> {
+  // createImageBitmap が使える環境では EXIF 回転も吸収できる
+  if (typeof createImageBitmap === 'function') {
+    try {
+      return await createImageBitmap(file, { imageOrientation: 'from-image' } as ImageBitmapOptions);
+    } catch {
+      // 一部フォーマット(HEIC等)で失敗することがある → フォールバックへ
+    }
+  }
+  // フォールバック: <img> でデコード
+  return await new Promise((resolve) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      // ImageBitmap 互換の最低限のプロパティだけ使うため as でキャスト
+      resolve(img as unknown as ImageBitmap);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      resolve(null);
+    };
+    img.src = url;
+  });
+}
+
+export async function compressImage(
+  file: File,
+  opts: CompressOptions = {}
+): Promise<CompressResult> {
+  // レシートは文字の可読性が重要なので長辺2000px・画質0.75を既定にする
+  const maxEdge = opts.maxEdge ?? 2000;
+  const quality = opts.quality ?? 0.75;
+  const skipUnderBytes = opts.skipUnderBytes ?? 300 * 1024;
+
+  const original: CompressResult = {
+    file,
+    compressed: false,
+    originalSize: file.size,
+    outputSize: file.size,
+  };
+
+  // 画像以外・GIF(アニメ劣化回避)・十分小さいものは触らない
+  if (
+    typeof document === 'undefined' ||
+    !file.type.startsWith('image/') ||
+    file.type === 'image/gif' ||
+    file.size <= skipUnderBytes
+  ) {
+    return original;
+  }
+
+  try {
+    const source = await decodeImage(file);
+    if (!source) return original;
+
+    const srcW = (source as ImageBitmap).width;
+    const srcH = (source as ImageBitmap).height;
+    if (!srcW || !srcH) return original;
+
+    const scale = Math.min(1, maxEdge / Math.max(srcW, srcH));
+    const w = Math.max(1, Math.round(srcW * scale));
+    const h = Math.max(1, Math.round(srcH * scale));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return original;
+    ctx.drawImage(source as CanvasImageSource, 0, 0, w, h);
+    if ('close' in source && typeof (source as ImageBitmap).close === 'function') {
+      (source as ImageBitmap).close();
+    }
+
+    const blob: Blob | null = await new Promise((resolve) =>
+      canvas.toBlob((b) => resolve(b), 'image/jpeg', quality)
+    );
+    if (!blob || blob.size === 0) return original;
+
+    // 圧縮しても小さくならないなら元を使う
+    if (blob.size >= file.size) return original;
+
+    const baseName = file.name.replace(/\.[^./\\]+$/, '') || 'receipt';
+    const outFile = new File([blob], `${baseName}.jpg`, {
+      type: 'image/jpeg',
+      lastModified: Date.now(),
+    });
+
+    return {
+      file: outFile,
+      compressed: true,
+      originalSize: file.size,
+      outputSize: outFile.size,
+    };
+  } catch {
+    return original;
+  }
+}


### PR DESCRIPTION
## Summary
レシート画像をアップロード前にクライアント側でリサイズ＋JPEG再エンコードして圧縮します。長期的な Firebase Storage の容量・転送帯域を削減する目的です。

## Changes
- **`lib/imageCompress.ts`（新規）**: 長辺2000pxへ縮小（拡大はしない）＋JPEG画質0.75で再エンコード。
  - EXIF回転は `createImageBitmap(imageOrientation: 'from-image')` で吸収、未対応環境は `<img>` でフォールバック。
  - 画像以外 / GIF / 300KB未満 / デコード不能 / 圧縮で小さくならない場合は**元ファイルをそのまま使用**（安全側）。
- **`attach`**: `handleUpload` で `compressImage` を通してからアップロード。圧縮率を console に出力。

## 効果
- スマホ写真（3〜8MB）→ 数百KB程度（おおむね80〜90%削減）見込み。
- 文字の可読性を優先して長辺2000px・画質0.75を既定に設定。

## Test Plan
- [x] `npm run build`（web）通過、追加Lintエラーなし
- [ ] 大きな写真を添付→ Storage 上のサイズが大幅減・文字が読める
- [ ] 既存レシートの「差し替え」でも圧縮される
- [ ] 小さい画像/非画像はそのまま（劣化しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * レシート添付時に画像ファイルが自動的に圧縮される機能を追加しました。

* **改善**
  * ファイル名のサニタイズ処理を強化し、セキュリティを向上させました。
  * ストレージへの保存プロセスを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->