### PR TITLE
fix(bot): Gmailカード通知のレイアウトをテキスト入力版に統一 (#124)

### DIFF
--- a/bot/src/line/flexMessage.ts
+++ b/bot/src/line/flexMessage.ts
@@ -191,12 +191,12 @@ export function buildCardUsageFlexMessage(info: CardUsageInfo): FlexMessage {
       type: 'box',
       layout: 'vertical',
       contents: [
-        // 店舗名
+        // 店舗名（テキスト入力版の支出カードと表記・サイズを統一）
         {
           type: 'text',
           text: merchant,
           weight: 'bold',
-          size: 'xl',
+          size: 'lg',
           wrap: true,
         },
         // 金額
@@ -204,9 +204,9 @@ export function buildCardUsageFlexMessage(info: CardUsageInfo): FlexMessage {
           type: 'text',
           text: `¥${amount.toLocaleString()}`,
           weight: 'bold',
-          size: 'xxl',
+          size: 'xl',
           color: '#0F172A',
-          margin: 'md',
+          margin: 'sm',
         },
         // カテゴリと日付
         {


### PR DESCRIPTION
Closes #124

## Summary
GmailからのLINE配信（カード利用通知 `buildCardUsageFlexMessage`）の店名・金額サイズが、テキスト入力版の支出カード（`buildTextExpenseFlexMessage`）と異なり統一感がありませんでした。新デザインのテキスト入力版に合わせます。

## Changes
- 店名 `size: 'xl' → 'lg'`（説明テキストと統一）
- 金額 `size: 'xxl' → 'xl'`、`margin: 'md' → 'sm'`
- 見出し（credit-card アイコン＋緑見出し）・カテゴリ行・アイコンボタン（共同費/個人費/立替/カテゴリ/レシート添付）は既存の新デザインを踏襲。

## 補足
コード上は #117 でアイコン/ボタンは新デザイン化済みです。本PRで残っていた見出し下の文字サイズ差を解消し、テキスト入力版とカード通知版を視覚的に統一します。マージ後に webhook を再デプロイして本番反映します。

## Test Plan
- [x] `npm run build`（bot/tsc）通過
- [ ] Gmailカード通知の店名/金額サイズがテキスト入力版と一致
- [ ] アイコン・ボタンの表示が従来通り

🤖 Generated with [Claude Code](https://claude.com/claude-code)