### PR TITLE
chore(deps): TypeScript を v6 / @types/node を v26 へアップグレード

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -33,9 +33,9 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.1.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/bot/tsconfig.json
+++ b/bot/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,13 +41,23 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
-        "@types/node": "^24.13.2",
+        "@types/node": "^26.1.0",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "bot/node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -11406,9 +11416,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -11461,6 +11471,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -11999,17 +12016,27 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
         "@tailwindcss/postcss": "^4.3.2",
-        "@types/node": "^24.13.2",
+        "@types/node": "^26.1.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.10",
         "postcss": "^8.5.16",
         "tailwindcss": "^4.3.2",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "web/node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@tailwindcss/postcss": "^4.3.2",
@@ -32,7 +32,7 @@
     "eslint-config-next": "^16.2.10",
     "postcss": "^8.5.16",
     "tailwindcss": "^4.3.2",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## 📋 変更内容

bot・web 両ワークスペースの TypeScript と @types/node をメジャーアップグレードします。

- `typescript` `^5.x` → `^6.0.3`（bot・web）
- `@types/node` `^24.x` → `^26.1.0`（bot・web）
- bot: TS6 で廃止された `moduleResolution: node10`（`"Node"`）に対応するため `module`/`moduleResolution` を `node16` へ移行（出力は従来どおり CommonJS を維持）

## 🎯 目的・背景

破壊的メジャーアップデートを個別PRで安全に取り込むため。

## 🔧 変更種別

- [x] 🔧 設定・ツール (Configuration/Tools)

## 🧪 テスト

- [x] bot: `npm run build --workspace=bot`（tsc）がゼロエラーで成功（出力が CommonJS のままであることを確認）
- [x] web: `npm run build --workspace=web` 成功（`typescript.ignoreBuildErrors: true` のため型エラーはビルド非ブロックの構成）
- [x] web: `npx tsc --noEmit` の残エラーは、既存の空スタブ route（`app/api/health`・`app/api/link` の「is not a module」）と、TS6 で既定有効化された `noUncheckedSideEffectImports` による `import "./globals.css"` の TS2882 のみ

## 📱 動作環境

- [x] Web (Vercel)
- [x] Bot (Firebase Functions)

## ⚠️ 注意事項

- bot の `moduleResolution` を `node16` に変更していますが、生成物は CommonJS のままです。
- `globals.css` の TS2882 は、当初 `web/globals.d.ts`（`declare module "*.css";`）で解消していましたが、最終版では収録を見送りました。ローカルで `tsc --noEmit` を実行した場合にのみ表示されます（必要になれば後続の小PRで追加できます）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkMJz2nesZ2G4xmmS7mh7H