### PR TITLE
chore(deps): @line/bot-sdk を v11 へアップグレード

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@google-cloud/functions-framework": "^5.0.5",
     "@google/generative-ai": "^0.24.1",
-    "@line/bot-sdk": "^10.0.0",
+    "@line/bot-sdk": "^11.1.0",
     "axios": "^1.18.1",
     "csv-parser": "^3.2.1",
     "dayjs": "^1.11.21",

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -1,6 +1,6 @@
 // Version: 2026-03-28-2200 - Force redeploy
 import express, { Express, Request, Response } from "express";
-import { Client, middleware } from "@line/bot-sdk";
+import { messagingApi, middleware } from "@line/bot-sdk";
 import { initializeApp, cert, getApps } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 import dayjs from "dayjs";
@@ -57,15 +57,17 @@ const config = {
   channelSecret: process.env.LINE_CHANNEL_SECRET || "dummy-secret-for-build",
 };
 
-let client: Client;
+let client: messagingApi.MessagingApiClient;
 try {
-  client = new Client(config);
+  client = new messagingApi.MessagingApiClient({
+    channelAccessToken: config.channelAccessToken,
+  });
 } catch (error) {
   console.warn(
     "LINE Client initialization failed during build, using dummy client"
   );
   // Create a dummy client for build analysis
-  client = {} as Client;
+  client = {} as messagingApi.MessagingApiClient;
 }
 
 // Firebase Admin setup
@@ -102,10 +104,10 @@ app.post("/webhook", async (req: Request, res: Response) => {
         if (event.type === "message" && event.message.type === "image") {
           // レシートOCR機能は廃止済み（replyMessageは無料）
           try {
-            await client.replyMessage(event.replyToken, {
+            await client.replyMessage({ replyToken: event.replyToken, messages: [{
               type: "text",
               text: "画像からの読み取り機能は終了しました。\nテキストで入力してください。\n例:「500 ランチ」「6/29 4800 家賃」",
-            });
+            }] });
           } catch (replyError) {
             console.warn("Failed to send OCR discontinued notice:", replyError);
           }
@@ -144,10 +146,10 @@ app.post("/webhook", async (req: Request, res: Response) => {
           (error as Error).message !== "Invalid reply token"
         ) {
           try {
-            await client.replyMessage(event.replyToken, {
+            await client.replyMessage({ replyToken: event.replyToken, messages: [{
               type: "text",
               text: "申し訳ございませんが、一時的なエラーが発生しました。しばらく後でお試しください。",
-            });
+            }] });
           } catch (replyError) {
             console.error("Failed to send error reply:", replyError);
           }
@@ -216,7 +218,7 @@ async function handleTextMessage(event: any) {
         if (summary.expenseCount === 0) {
           // データなしの場合
           const emptyMessage = buildEmptyExpenseSummaryFlexMessage(isGroupContext, webAppUrl);
-          await client.replyMessage(event.replyToken, emptyMessage);
+          await client.replyMessage({ replyToken: event.replyToken, messages: [emptyMessage] });
         } else {
           // カテゴリ別データの整形
           const totalIncluded = summary.includedTotalAmount || 1; // ゼロ除算防止
@@ -257,14 +259,14 @@ async function handleTextMessage(event: any) {
           };
 
           const flexMessage = buildExpenseSummaryFlexMessage(summaryInfo);
-          await client.replyMessage(event.replyToken, flexMessage);
+          await client.replyMessage({ replyToken: event.replyToken, messages: [flexMessage] });
         }
       } catch (error) {
         console.error("Error fetching expenses:", error);
 
         // Fallback response (テキストメッセージ)
         try {
-          await client.replyMessage(event.replyToken, {
+          await client.replyMessage({ replyToken: event.replyToken, messages: [{
             type: "text",
             text:
               `家計簿\n\n現在データを読み込み中です...\n${
@@ -276,7 +278,7 @@ async function handleTextMessage(event: any) {
               (event.source.type === "group" && event.source.groupId
                 ? `&lineGroupId=${encodeURIComponent(event.source.groupId)}`
                 : ""),
-          });
+          }] });
         } catch (replyError) {
           console.error("Failed to send fallback reply:", replyError);
         }
@@ -299,25 +301,25 @@ async function handleTextMessage(event: any) {
         `=== FEEDBACK COMMAND MATCHED: Creating GitHub issue from feedback: "${feedbackText}" ===`
       );
       if (!feedbackText) {
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: "フィードバック内容を入力してください。\n例: 「要望 月別のグラフが見たい」\n「不具合 レシートが読み取れない」",
-        });
+        }] });
         return;
       }
       try {
         const result = await createIssueFromFeedback(feedbackText);
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: result.message,
-        });
+        }] });
       } catch (error) {
         console.error("Error creating issue from feedback:", error);
         try {
-          await client.replyMessage(event.replyToken, {
+          await client.replyMessage({ replyToken: event.replyToken, messages: [{
             type: "text",
             text: "Issueの作成に失敗しました。\n時間をおいてもう一度お試しください。",
-          });
+          }] });
         } catch (replyError) {
           console.error("Failed to send feedback error reply:", replyError);
         }
@@ -370,14 +372,14 @@ async function handleTextMessage(event: any) {
           console.log("Failed to get current category setting:", error);
         }
 
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: `利用可能なカテゴリー:\n\n${validCategories
             .map((c) => "• " + c)
             .join(
               "\n"
             )}\n\n現在のデフォルト: ${currentCategory}\n\n設定方法:\n「カテゴリー 食費」のように送信してください`,
-        });
+        }] });
         return;
       }
 
@@ -392,10 +394,10 @@ async function handleTextMessage(event: any) {
         `=== CATEGORY COMMAND: Extracted category: "${category}" ===`
       );
       if (!category) {
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: "カテゴリー名を指定してください。\n例: 「カテゴリー 食費」\n\n利用可能なカテゴリー:\n• 食費\n• 日用品\n• 交通費\n• 医療費\n• 娯楽費\n• 衣服費\n• 教育費\n• 通信費\n• その他",
-        });
+        }] });
         return;
       }
 
@@ -412,12 +414,12 @@ async function handleTextMessage(event: any) {
       ];
 
       if (!validCategories.includes(category)) {
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: `「${category}」は有効なカテゴリーではありません。\n\n利用可能なカテゴリー:\n${validCategories
             .map((c) => "• " + c)
             .join("\n")}`,
-        });
+        }] });
         return;
       }
 
@@ -437,16 +439,16 @@ async function handleTextMessage(event: any) {
           verifySettings
         );
 
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: `デフォルトカテゴリーを「${category}」に設定しました！\n\n今後の支出入力は自動的に「${category}」カテゴリーになります。\n\n変更するには「カテゴリー [新しいカテゴリー]」と送信してください。`,
-        });
+        }] });
       } catch (error) {
         console.error("Error saving user settings:", error);
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: "カテゴリーの設定に失敗しました。もう一度お試しください。",
-        });
+        }] });
       }
       return;
     }
@@ -461,10 +463,10 @@ async function handleTextMessage(event: any) {
       console.log(`=== COMMAND MATCHED: Processing グループ作成 command ===`);
       const groupName = text.replace("グループ作成 ", "").trim();
       if (!groupName) {
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: "グループ名を指定してください。\n例: 「グループ作成 田中夫婦の家計簿」",
-        });
+        }] });
         return;
       }
 
@@ -475,16 +477,16 @@ async function handleTextMessage(event: any) {
 
         const replyText = `グループ「${groupName}」を作成しました！\n\n招待コード: ${group?.inviteCode}\n\nこのコードを共有して、パートナーを招待してください。\n\n使い方:\n「参加 ${group?.inviteCode} 表示名」で参加できます。`;
 
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: replyText,
-        });
+        }] });
       } catch (error) {
         console.error("Error creating group:", error);
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: "グループの作成に失敗しました。もう一度お試しください。",
-        });
+        }] });
       }
       return;
     }
@@ -498,10 +500,10 @@ async function handleTextMessage(event: any) {
       console.log(`=== COMMAND MATCHED: Processing 参加 command ===`);
       const parts = text.replace("参加 ", "").trim().split(" ");
       if (parts.length < 2) {
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: "招待コードと表示名を指定してください。\n例: 「参加 ABC123 太郎」",
-        });
+        }] });
         return;
       }
 
@@ -516,26 +518,26 @@ async function handleTextMessage(event: any) {
         );
 
         if (!groupId) {
-          await client.replyMessage(event.replyToken, {
+          await client.replyMessage({ replyToken: event.replyToken, messages: [{
             type: "text",
             text: "無効な招待コードです。正しいコードを確認してください。",
-          });
+          }] });
           return;
         }
 
         const members = await getGroupMembers(groupId);
         const memberNames = members.map((m) => m.displayName).join("、");
 
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: `グループに参加しました！\n\nメンバー: ${memberNames}\n\nこれからの支出は共有され、誰が何を支払ったかが記録されます。`,
-        });
+        }] });
       } catch (error) {
         console.error("Error joining group:", error);
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: "グループへの参加に失敗しました。もう一度お試しください。",
-        });
+        }] });
       }
       return;
     }
@@ -551,10 +553,10 @@ async function handleTextMessage(event: any) {
         const groups = await getUserGroups(event.source.userId);
 
         if (groups.length === 0) {
-          await client.replyMessage(event.replyToken, {
+          await client.replyMessage({ replyToken: event.replyToken, messages: [{
             type: "text",
             text: "まだグループに参加していません。\n\n新しいグループを作成するか、招待コードで参加してください。\n\n• グループ作成 [名前]\n• 参加 [コード] [表示名]",
-          });
+          }] });
           return;
         }
 
@@ -567,16 +569,16 @@ async function handleTextMessage(event: any) {
           replyText += `招待コード: ${group.inviteCode}\n\n`;
         }
 
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: replyText,
-        });
+        }] });
       } catch (error) {
         console.error("Error getting groups:", error);
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: "グループ情報の取得に失敗しました。",
-        });
+        }] });
       }
       return;
     }
@@ -587,10 +589,10 @@ async function handleTextMessage(event: any) {
       try {
         // グループコンテキストが必要
         if (event.source.type !== "group") {
-          await client.replyMessage(event.replyToken, {
+          await client.replyMessage({ replyToken: event.replyToken, messages: [{
             type: "text",
             text: "立替一覧はグループ内でのみ利用できます。\n\nLINEグループで「立替一覧」と送信してください。",
-          });
+          }] });
           return;
         }
 
@@ -598,10 +600,10 @@ async function handleTextMessage(event: any) {
         const summaries = await getAdvanceSummaryByUser(lineGroupId, true);
 
         if (summaries.length === 0) {
-          await client.replyMessage(event.replyToken, {
+          await client.replyMessage({ replyToken: event.replyToken, messages: [{
             type: "text",
             text: "未精算の立替はありません。\n\n支出登録時に「立替」ボタンを押すと、立替として記録できます。",
-          });
+          }] });
           return;
         }
 
@@ -637,16 +639,16 @@ async function handleTextMessage(event: any) {
           }
         }
 
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: replyText,
-        });
+        }] });
       } catch (error) {
         console.error("Error getting advance list:", error);
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: "立替一覧の取得に失敗しました。",
-        });
+        }] });
       }
       return;
     }
@@ -657,10 +659,10 @@ async function handleTextMessage(event: any) {
       try {
         // グループコンテキストが必要
         if (event.source.type !== "group") {
-          await client.replyMessage(event.replyToken, {
+          await client.replyMessage({ replyToken: event.replyToken, messages: [{
             type: "text",
             text: "精算はグループ内でのみ利用できます。\n\nLINEグループで「精算」と送信してください。",
-          });
+          }] });
           return;
         }
 
@@ -668,10 +670,10 @@ async function handleTextMessage(event: any) {
         const pendingAdvances = await getPendingAdvances(lineGroupId, true);
 
         if (pendingAdvances.length === 0) {
-          await client.replyMessage(event.replyToken, {
+          await client.replyMessage({ replyToken: event.replyToken, messages: [{
             type: "text",
             text: "精算する立替がありません。",
-          });
+          }] });
           return;
         }
 
@@ -691,10 +693,10 @@ async function handleTextMessage(event: any) {
         const settleResult = await settleAdvances(expenseIds, lineGroupId, true);
 
         if (settleResult.settled === 0) {
-          await client.replyMessage(event.replyToken, {
+          await client.replyMessage({ replyToken: event.replyToken, messages: [{
             type: "text",
             text: "精算処理でエラーが発生しました。対象の立替が見つかりませんでした。",
-          });
+          }] });
           return;
         }
 
@@ -704,16 +706,16 @@ async function handleTextMessage(event: any) {
         }
         resultText += "\n\n次の立替からまた集計を開始します。";
 
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: resultText,
-        });
+        }] });
       } catch (error) {
         console.error("Error settling advances:", error);
-        await client.replyMessage(event.replyToken, {
+        await client.replyMessage({ replyToken: event.replyToken, messages: [{
           type: "text",
           text: "精算処理に失敗しました。",
-        });
+        }] });
       }
       return;
     }
@@ -745,10 +747,10 @@ async function handleTextMessage(event: any) {
     } catch (error) {
       console.error("Background expense processing failed:", error);
       // Send error notification
-      await client.pushMessage(targetId, {
+      await client.pushMessage({ to: targetId, messages: [{
         type: "text",
         text: "支出の保存で問題が発生しました。データが正しく記録されていない可能性があります。",
-      }).catch((pushError) =>
+      }] }).catch((pushError) =>
         console.error("Failed to send error notification:", pushError)
       );
     }
@@ -759,10 +761,10 @@ async function handleTextMessage(event: any) {
       const targetId = event.source.type === "group"
         ? event.source.groupId
         : event.source.userId;
-      await client.pushMessage(targetId, {
+      await client.pushMessage({ to: targetId, messages: [{
         type: "text",
         text: "メッセージの処理中にエラーが発生しました。もう一度お試しください。",
-      });
+      }] });
     } catch (notifyError) {
       console.error("Failed to send error notification:", notifyError);
     }
@@ -1002,14 +1004,14 @@ async function processExpenseInBackground(
       let errorNotified = false;
       if (replyToken) {
         try {
-          await client.replyMessage(replyToken, profileErrorMessage);
+          await client.replyMessage({ replyToken: replyToken, messages: [profileErrorMessage] });
           errorNotified = true;
         } catch (replyError) {
           console.warn("replyMessage failed for profile error, falling back to pushMessage:", replyError);
         }
       }
       if (!errorNotified) {
-        await client.pushMessage(targetId, profileErrorMessage);
+        await client.pushMessage({ to: targetId, messages: [profileErrorMessage] });
       }
       return; // 処理を中断（データは書き込まない）
     }
@@ -1142,10 +1144,10 @@ async function handleJoin(event: any) {
 
     // Send welcome message with error handling
     try {
-      await client.pushMessage(lineGroupId, {
+      await client.pushMessage({ to: lineGroupId, messages: [{
         type: "text",
         text: "家計簿ボットがグループに参加しました！\n\nレシート画像を送信すると支出を自動記録\n「500 ランチ」のようにテキストでも記録\n「家計簿」で支出一覧を表示\n\nグループメンバーの支出が自動的に共有されます",
-      });
+      }] });
 
       console.log(
         `Bot successfully joined and sent welcome to LINE group: ${lineGroupId}`
@@ -1177,10 +1179,10 @@ async function handleMemberJoined(event: any) {
         await new Promise((resolve) => setTimeout(resolve, 500));
 
         // Use pushMessage instead of replyMessage for better compatibility
-        await client.pushMessage(lineGroupId, {
+        await client.pushMessage({ to: lineGroupId, messages: [{
           type: "text",
           text: "新しいメンバーがグループに参加しました！\n家計簿ボットで支出を記録・共有できます。\n\n「家計簿」と送信すると使い方を確認できます。",
-        });
+        }] });
 
         console.log(
           `Successfully sent welcome message for new member in group: ${lineGroupId}`

--- a/bot/src/line/flexMessage.ts
+++ b/bot/src/line/flexMessage.ts
@@ -4,12 +4,16 @@
  * カード利用通知用のリッチなメッセージを生成
  */
 
-import { Client, FlexMessage, FlexBubble, FlexComponent } from '@line/bot-sdk';
+import { messagingApi } from '@line/bot-sdk';
+
+type FlexMessage = messagingApi.FlexMessage;
+type FlexBubble = messagingApi.FlexBubble;
+type FlexComponent = messagingApi.FlexComponent;
 
 // LINEクライアントの初期化
-let lineClient: Client | null = null;
+let lineClient: messagingApi.MessagingApiClient | null = null;
 
-function getLineClient(): Client {
+function getLineClient(): messagingApi.MessagingApiClient {
   if (!lineClient) {
     const channelAccessToken = process.env.LINE_CHANNEL_TOKEN;
     const channelSecret = process.env.LINE_CHANNEL_SECRET;
@@ -18,9 +22,8 @@ function getLineClient(): Client {
       throw new Error('LINE credentials not configured');
     }
 
-    lineClient = new Client({
+    lineClient = new messagingApi.MessagingApiClient({
       channelAccessToken,
-      channelSecret,
     });
   }
   return lineClient;
@@ -360,7 +363,7 @@ export async function sendCardUsageNotification(
   const client = getLineClient();
   const message = buildCardUsageFlexMessage(info);
 
-  await client.pushMessage(lineGroupId, message);
+  await client.pushMessage({ to: lineGroupId, messages: [message] });
   console.log(`Card usage notification sent to ${lineGroupId}`);
 }
 
@@ -373,10 +376,10 @@ export async function sendTextMessage(
 ): Promise<void> {
   const client = getLineClient();
 
-  await client.pushMessage(targetId, {
+  await client.pushMessage({ to: targetId, messages: [{
     type: 'text',
     text,
-  });
+  }] });
 }
 
 /**
@@ -634,7 +637,7 @@ export async function sendTextExpenseNotification(
 
   if (replyToken) {
     try {
-      await client.replyMessage(replyToken, message);
+      await client.replyMessage({ replyToken: replyToken, messages: [message] });
       console.log(`Text expense notification sent via replyMessage (free) to ${targetId}`);
       return;
     } catch (replyError) {
@@ -645,7 +648,7 @@ export async function sendTextExpenseNotification(
     }
   }
 
-  await client.pushMessage(targetId, message);
+  await client.pushMessage({ to: targetId, messages: [message] });
   console.log(`Text expense notification sent via pushMessage to ${targetId}`);
 }
 

--- a/bot/src/line/postback.ts
+++ b/bot/src/line/postback.ts
@@ -4,7 +4,10 @@
  * カード利用通知・テキスト入力のボタン押下を処理
  */
 
-import { WebhookEvent, PostbackEvent, Client } from '@line/bot-sdk';
+import { webhook, messagingApi } from '@line/bot-sdk';
+
+type WebhookEvent = webhook.Event;
+type PostbackEvent = webhook.PostbackEvent;
 import { getFirestore } from 'firebase-admin/firestore';
 import { PostbackActionData, ExpenseStatus } from '../gmail/types';
 import { sendStatusUpdateConfirmation, sendTextMessage, buildCategorySelectCarousel, CategorySelectInfo } from './flexMessage';
@@ -21,9 +24,9 @@ interface ExtendedPostbackActionData extends PostbackActionData {
 }
 
 // LINEクライアントの初期化
-let lineClient: Client | null = null;
+let lineClient: messagingApi.MessagingApiClient | null = null;
 
-function getLineClient(): Client {
+function getLineClient(): messagingApi.MessagingApiClient {
   if (!lineClient) {
     const channelAccessToken = process.env.LINE_CHANNEL_TOKEN;
     const channelSecret = process.env.LINE_CHANNEL_SECRET;
@@ -32,9 +35,8 @@ function getLineClient(): Client {
       throw new Error('LINE credentials not configured');
     }
 
-    lineClient = new Client({
+    lineClient = new messagingApi.MessagingApiClient({
       channelAccessToken,
-      channelSecret,
     });
   }
   return lineClient;
@@ -118,11 +120,11 @@ export async function handlePostback(event: PostbackEvent): Promise<void> {
 
     // 立替の場合は立替者を記録
     if (action === 'advance') {
-      const userId = event.source.userId;
+      const userId = event.source!.userId;
       if (!userId) {
         console.error('Cannot process advance: userId is missing', {
           expenseId,
-          sourceType: event.source.type,
+          sourceType: event.source!.type,
         });
         return; // 立替者不明では処理できない
       }
@@ -135,9 +137,9 @@ export async function handlePostback(event: PostbackEvent): Promise<void> {
     console.log(`Expense ${expenseId} status updated to ${newStatus}`);
 
     // 確認メッセージを送信
-    const replyTarget = event.source.type === 'group'
+    const replyTarget = event.source!.type === 'group'
       ? (event.source as any).groupId
-      : event.source.userId;
+      : event.source!.userId;
 
     if (replyTarget && (action === 'shared' || action === 'personal' || action === 'advance')) {
       await sendStatusUpdateConfirmation(
@@ -176,9 +178,9 @@ async function handleTextExpensePostback(
     return;
   }
 
-  const replyTarget = event.source.type === 'group'
+  const replyTarget = event.source!.type === 'group'
     ? (event.source as any).groupId
-    : event.source.userId;
+    : event.source!.userId;
 
   switch (action) {
     case 'confirm':
@@ -204,7 +206,7 @@ async function handleTextExpensePostback(
         updatedAt: new Date(),
       });
       if (replyTarget) {
-        const editUrl = `https://line-kakeibo.vercel.app/expenses?edit=${expenseId}&lineId=${event.source.userId}`;
+        const editUrl = `https://line-kakeibo.vercel.app/expenses?edit=${expenseId}&lineId=${event.source!.userId}`;
         await sendTextMessage(
           replyTarget,
           `以下のリンクから修正できます\n${editUrl}`
@@ -214,11 +216,11 @@ async function handleTextExpensePostback(
 
     case 'advance': {
       // 立替として記録（合計に含める）
-      const userId = event.source.userId;
+      const userId = event.source!.userId;
       if (!userId) {
         console.error('Cannot process text expense advance: userId is missing', {
           expenseId,
-          sourceType: event.source.type,
+          sourceType: event.source!.type,
         });
         return; // 立替者不明では処理できない
       }
@@ -308,9 +310,9 @@ async function handleShowCategorySelect(
 ): Promise<void> {
   const { expenseId, source } = actionData;
 
-  const replyTarget = event.source.type === 'group'
+  const replyTarget = event.source!.type === 'group'
     ? (event.source as any).groupId
-    : event.source.userId;
+    : event.source!.userId;
 
   if (!replyTarget) {
     console.warn('Cannot determine reply target for category select');
@@ -344,7 +346,7 @@ async function handleShowCategorySelect(
   const carousel = buildCategorySelectCarousel(carouselInfo);
   const client = getLineClient();
 
-  await client.pushMessage(replyTarget, carousel);
+  await client.pushMessage({ to: replyTarget, messages: [carousel] });
   console.log(`Category select carousel sent for expense ${expenseId}`);
 }
 
@@ -383,9 +385,9 @@ async function handleSetCategory(
     updatedAt: new Date(),
   });
 
-  const replyTarget = event.source.type === 'group'
+  const replyTarget = event.source!.type === 'group'
     ? (event.source as any).groupId
-    : event.source.userId;
+    : event.source!.userId;
 
   if (replyTarget) {
     await sendTextMessage(

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       "dependencies": {
         "@google-cloud/functions-framework": "^5.0.5",
         "@google/generative-ai": "^0.24.1",
-        "@line/bot-sdk": "^10.0.0",
+        "@line/bot-sdk": "^11.1.0",
         "axios": "^1.18.1",
         "csv-parser": "^3.2.1",
         "dayjs": "^1.11.21",
@@ -2355,27 +2355,15 @@
       }
     },
     "node_modules/@line/bot-sdk": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-10.0.0.tgz",
-      "integrity": "sha512-Uj6ZVivMDzZUV4Jm/RSsJinryyj3HS+fnyYob+mNl4/uUDWQ2OAEZDVopl0v0tcjXlCRC6GUB+nfEZLgBFI+dg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-11.1.0.tgz",
+      "integrity": "sha512-i8EQziuuvNitMrqSHQfzmjiyz9CBA7KjhmAJhCWhZzbI0kElfbaOOVhxEYxJGul5Aar9dv6HrHUgPeDLNIghEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "^22.0.0"
+        "@types/node": "^24.0.0"
       },
       "engines": {
-        "node": ">=20"
-      },
-      "optionalDependencies": {
-        "axios": "^1.7.4"
-      }
-    },
-    "node_modules/@line/bot-sdk/node_modules/@types/node": {
-      "version": "22.15.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.34.tgz",
-      "integrity": "sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
+        "node": ">=22"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -11917,12 +11905,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",


### PR DESCRIPTION
## 📋 変更内容

bot の `@line/bot-sdk` を v10 から v11 へアップグレードし、レガシー `Client` から新 `messagingApi` クライアントへ移行します（挙動は不変）。

- `@line/bot-sdk` `^10.0.0` → `^11.1.0`
- `import { Client }` → `import { messagingApi }`、`new Client({...})` → `new messagingApi.MessagingApiClient({ channelAccessToken })`
- `replyMessage` / `pushMessage` を新しいオブジェクト引数形式（`messages` は配列）へ全 **43 箇所**書き換え
  - `client.replyMessage(replyToken, msg)` → `client.replyMessage({ replyToken, messages: [msg] })`
  - `client.pushMessage(to, msg)` → `client.pushMessage({ to, messages: [msg] })`
- 型を新名前空間へ更新（Flex 系 → `messagingApi.*`、Webhook 系 → `webhook.*`）
- `middleware` は署名検証用に従来どおり利用、`getProfile` / `getGroupMemberProfile` は位置引数のままで変更不要

## 🎯 目的・背景

破壊的メジャーアップデートを個別PRで安全に取り込むため。SDK の API 追従のみで、bot のロジックは変更していません。

## 🔧 変更種別

- [x] 🔧 設定・ツール (Configuration/Tools)
- [x] 🔨 リファクタリング (Refactoring)

## 🧪 テスト

- [x] `npm run build --workspace=bot`（tsc）がゼロエラーで成功
- [x] grep で旧 `new Client(` および 2 位置引数の reply/push 呼び出しが残っていないことを確認（全 43 箇所が新形式）
- [ ] 実機（LINE）での送受信の動作確認を推奨

## 📱 動作環境

- [x] Bot (Firebase Functions)
- [x] 外部API (LINE)

## ⚠️ 注意事項

- v11 で Webhook イベントの `source` が optional 化されたため、既存の前提を保つ形で `postback.ts` に非 null 表明（`event.source!`）を追加しています（挙動は不変）。
- メッセージ送受信のふるまいは維持していますが、SDK 全面移行のため、実機での返信・プッシュ・プロフィール取得の動作確認を推奨します。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkMJz2nesZ2G4xmmS7mh7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkMJz2nesZ2G4xmmS7mh7H)_