### PR TITLE
chore(web): flex-shrink-0 を Tailwind v4 推奨の shrink-0 に統一

### DIFF
--- a/web/app/expenses/page.tsx
+++ b/web/app/expenses/page.tsx
@@ -794,7 +794,7 @@ function ExpensesPageContent() {
                   { Icon: LinkIcon, title: "リンクから確認・編集", desc: "届いたリンクを開くと、ここに支出が表示されます。" },
                 ].map(({ Icon, title, desc }, i) => (
                   <li key={i} className="flex items-start gap-3 rounded-xl border border-line bg-fg/[0.02] p-3">
-                    <span className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-lg bg-accent/12 text-accent">
+                    <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-accent/12 text-accent">
                       <Icon className="h-4 w-4" strokeWidth={2.1} />
                     </span>
                     <div className="min-w-0">
@@ -843,7 +843,7 @@ function ExpensesPageContent() {
                           </p>
                         </div>
 
-                        <div className="flex-shrink-0">
+                        <div className="shrink-0">
                           <p className="text-right text-xl font-bold tabular-nums text-fg sm:text-2xl">
                             ¥{expense.amount.toLocaleString()}
                           </p>
@@ -923,7 +923,7 @@ function ExpensesPageContent() {
                                   <span className="mr-2 min-w-0 flex-1 break-words text-muted">
                                     {item.name}
                                   </span>
-                                  <span className="flex-shrink-0 font-medium tabular-nums text-fg">
+                                  <span className="shrink-0 font-medium tabular-nums text-fg">
                                     ¥{item.price.toLocaleString()}
                                   </span>
                                 </li>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -330,7 +330,7 @@ export default function Settings() {
                   const Icon = v.icon;
                   return (
                   <div key={category.id} className="flex items-center gap-3">
-                    <span className={`grid h-7 w-7 flex-shrink-0 place-items-center rounded-lg ${v.bg} ${v.fg}`}>
+                    <span className={`grid h-7 w-7 shrink-0 place-items-center rounded-lg ${v.bg} ${v.fg}`}>
                       <Icon className="h-4 w-4" strokeWidth={2.1} />
                     </span>
                     <span className="w-24 truncate text-sm text-fg">{category.name}</span>

--- a/web/components/GuestGuide.tsx
+++ b/web/components/GuestGuide.tsx
@@ -55,7 +55,7 @@ export default function GuestGuide({ className = '' }: { className?: string }) {
       <ol className="mb-6 space-y-4">
         {STEPS.map((step, index) => (
           <li key={step.title} className="flex gap-3">
-            <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-accent/12 text-sm font-bold text-accent">
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-accent/12 text-sm font-bold text-accent">
               {index + 1}
             </span>
             <div className="min-w-0">
@@ -103,7 +103,7 @@ export default function GuestGuide({ className = '' }: { className?: string }) {
               key={item.command}
               className="flex items-center gap-2 rounded-lg border border-line bg-fg/[0.02] px-3 py-2"
             >
-              <code className="flex-shrink-0 rounded border border-accent/20 bg-accent/10 px-1.5 py-0.5 text-xs font-semibold text-accent">
+              <code className="shrink-0 rounded border border-accent/20 bg-accent/10 px-1.5 py-0.5 text-xs font-semibold text-accent">
                 {item.command}
               </code>
               <span className="text-xs leading-tight text-muted">{item.description}</span>


### PR DESCRIPTION
## 📋 変更内容

非推奨クラス `flex-shrink-0` を Tailwind v4 推奨の `shrink-0` に置換します(計 6 箇所)。

- `web/app/settings/page.tsx`(1 箇所)
- `web/components/GuestGuide.tsx`(2 箇所)
- `web/app/expenses/page.tsx`(3 箇所)

## 🎯 目的・背景

発端は Codex レビュー(#131 の P2)の「v4 では `flex-shrink-*` が削除され CSS を出力しない」という指摘ですが、master(91ad335)のビルド出力で検証した結果、この前提は誤りでした。実際には v4 も `flex-shrink-0` をエイリアスとして出力し続けています:

```
.flex-shrink-0,.shrink-0{flex-shrink:0}
```

したがって修正すべきバグはなく、本 PR は非推奨記法を推奨記法へ揃える命名整理のみです(急ぎの変更ではありません)。

## 🔧 変更種別

- [x] 🔨 リファクタリング (Refactoring)

## 🧪 テスト

- [x] `npm run build --workspace=web` 成功
- [x] 置換後の生成 CSS に `.shrink-0{flex-shrink:0}` が出力されることを確認
- [x] 他の非推奨 flex 系ユーティリティ(`flex-grow-*`・値付き `flex-shrink-*`)が web に残っていないことを確認

## 📱 動作環境

- [x] Web (Vercel)

## ⚠️ 注意事項

- クラス名の置換のみで、適用されるスタイルは置換前後で同一です。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkMJz2nesZ2G4xmmS7mh7H