### PR TITLE
fix(web): Tailwind v4 の backdrop-blur を v3 と同値に戻す / 依存を入れる CI を Node 22 へ

### DIFF
--- a/.github/workflows/ci-cd-old.yml
+++ b/.github/workflows/ci-cd-old.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: package-lock.json
           
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: package-lock.json
           
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: package-lock.json
           
@@ -144,7 +144,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
         
       - name: Run security audit for Web
         working-directory: ./web

--- a/.github/workflows/claude-code-workflow.yml
+++ b/.github/workflows/claude-code-workflow.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Claude Code environment
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Extract task from comment
         id: extract-task
@@ -121,7 +121,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: |
@@ -149,7 +149,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           
       # コードメトリクスの計算
       - name: Calculate code metrics

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -35,6 +35,12 @@ module.exports = {
         glass: '0 1px 1px rgb(0 0 0 / 0.04), 0 8px 24px -12px rgb(15 23 42 / 0.18)',
         'glass-lg': '0 1px 1px rgb(0 0 0 / 0.05), 0 18px 48px -20px rgb(15 23 42 / 0.30)',
       },
+      blur: {
+        // 同じく v4 で blur スケールが 1 段ずれた（v3 `sm`=4px -> v4 `sm`=8px）。
+        // v4 は blur と backdrop-blur で `--blur-*` を共有するため、ここを固定すると
+        // `backdrop-blur-sm`（モーダル背景 2 箇所）が v3 と同じ 4px に戻る。
+        sm: '4px',
+      },
       keyframes: {
         blob: {
           '0%,100%': { transform: 'translate(0,0) scale(1)' },


### PR DESCRIPTION
## 📋 変更内容

#131（Tailwind v4）と #133（firebase-admin 14 / Node 22）のレビューで見つかった**取りこぼしの修正**です。

### 1. `backdrop-blur-sm` が 2 倍にボケていた（見た目の退行）

Tailwind v4 は blur スケールを 1 段ずらしており（v3 `sm`=4px → v4 `sm`=8px）、さらに v4 は blur と backdrop-blur で `--blur-*` を共有します。その結果 #131 マージ後の master では、モーダル背景 2 箇所の `backdrop-blur-sm` が **4px → 8px** に倍化していました。

- `web/app/expenses/page.tsx:1040`（編集ドロワーの背景）
- `web/app/expenses/page.tsx:1205`（もう 1 つのオーバーレイ）

`tailwind.config.js` の `theme.extend.blur.sm` を `4px` に固定して v3 と同値に戻します（#131 で入れた `boxShadow.sm` の固定と同じ手法）。

**検証（出力 CSS の実測）**

| | v3 (#131 前) | v4 (#131 後) | 本PR |
|---|---|---|---|
| `.backdrop-blur-sm` | `blur(4px)` | `blur(8px)` ❌ | `blur(4px)` ✅ |
| `.shadow-sm` | `0 1px 2px 0 rgb(0 0 0/.05)` | 同左（#131で固定済） | 同左 ✅ |

### 2. 依存をインストールする CI が Node 20 のままだった

#133 で `firebase-admin@14`（`engines: node>=22`）を入れ、root/bot/web の `engines` と Functions ランタイムを 22 に上げましたが、`pr-checks` / `ci-cd` / `deploy-*` 以外の**リポジトリの依存を入れるワークフロー**が Node 20 のまま残っていました。

- `ci-cd-old.yml`（`npm ci` + web/bot ビルド、Vercel/Firebase デプロイジョブを含む・現在は secret 未設定で no-op）
- `claude-code-workflow.yml`（`npm install`）
- `code-review.yml`（`npm ci && npm run build`）

いずれも Node 20 → 22 に統一しました。

> `gpt-review.yml` / `ai-review-mcp.yml` はレビュー用 SDK しか入れずリポジトリの依存をビルドしないため、対象外としています。

## 🔧 変更種別

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 設定・ツール (Configuration/Tools)

## 🧪 テスト

- [x] `npm run build --workspace=web` 成功
- [x] `npm run lint --workspace=web` 成功（0 errors）
- [x] 出力 CSS で `.backdrop-blur-sm` が `blur(4px)` に戻ることを実測確認
- [x] `.shadow-sm` の v3 同値固定が維持されていることを確認

## 📱 動作環境

- [x] Web (Vercel)

## ⚠️ 注意事項

- `ci-cd-old.yml` は `pr-checks` / `ci-cd` と重複する**旧デプロイ経路**で、現在は secret 未設定のため実質 no-op（`continue-on-error`）です。本PRでは Node 版だけ揃えていますが、**将来的には削除/無効化を検討**したほうがよいと思われます（本PRの範囲外）。