### PR TITLE
fix(ci): Firebase デプロイジョブの認証・依存・health URL を修正

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -274,24 +274,33 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
-          
+          cache: 'npm'
+
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:
           name: bot-build
           path: bot/
-          
+
+      # firebase deploy は関数の一覧を取得するために bot/ のコードを実際に読み込む。
+      # 成果物（dist）だけでは依存が解決できないため、ワークスペース全体を入れる。
+      - name: Install dependencies
+        run: npm ci
+
       - name: Authenticate to Google Cloud
+        id: auth
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
-          
+
       - name: Deploy to Firebase
         run: |
           npm install -g firebase-tools@latest
-          firebase deploy --only functions,firestore:rules,firestore:indexes --project ${{ secrets.FIREBASE_PROJECT_ID }}
+          firebase deploy --only functions,firestore:rules,firestore:indexes --project "$FIREBASE_PROJECT_ID"
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
+          # 未設定なら .firebaserc の default を使う（空文字を渡すと deploy が落ちるため）
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID || 'default' }}
 
   # デプロイ後の健全性チェック
   post-deploy-check:
@@ -299,26 +308,32 @@ jobs:
     needs: [deploy-web, deploy-bot]
     if: always() && (needs.deploy-web.result == 'success' || needs.deploy-bot.result == 'success')
     steps:
+      # web の /api/health は静的エクスポートのため無効化されている（GETは405）。
+      # 代わりにトップページの応答でデプロイの生存を確認する。
       - name: Health check - Web
         if: needs.deploy-web.result == 'success'
         run: |
-          response=$(curl -s -o /dev/null -w "%{http_code}" https://your-app.vercel.app/api/health)
-          if [ $response -eq 200 ]; then
+          response=$(curl -s -L -o /dev/null -w "%{http_code}" --max-time 30 https://line-kakeibo.vercel.app/)
+          if [ "$response" -eq 200 ]; then
             echo "✅ Web app is healthy"
           else
-            echo "❌ Web app health check failed"
+            echo "❌ Web app health check failed (HTTP $response)"
             exit 1
           fi
-          
+
+      # /health は webhook 関数（asia-northeast1）が持つ express ルート。
+      # 旧URL（us-central1 直下の /health）は存在せず 404 になる。
       - name: Health check - Bot
         if: needs.deploy-bot.result == 'success'
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID || 'line-kakeibo-0410' }}
         run: |
-          # Firebase Functions health check
-          response=$(curl -s -o /dev/null -w "%{http_code}" https://us-central1-${{ secrets.FIREBASE_PROJECT_ID }}.cloudfunctions.net/health)
-          if [ $response -eq 200 ]; then
+          response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 \
+            "https://asia-northeast1-${FIREBASE_PROJECT_ID}.cloudfunctions.net/webhook/health")
+          if [ "$response" -eq 200 ]; then
             echo "✅ Bot functions are healthy"
           else
-            echo "❌ Bot health check failed"
+            echo "❌ Bot health check failed (HTTP $response)"
             exit 1
           fi
           

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,9 +11,12 @@ env:
   NODE_VERSION: '22'
 
 # 同時実行の制御
+# PR は新しい push で古い run を打ち切ってよいが、master push は deploy を含む。
+# 連続 push で firebase deploy の途中がキャンセルされると部分デプロイになるため、
+# キャンセルは PR のときだけ有効にする。
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # 変更検知ジョブ

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,9 +32,15 @@ jobs:
             web:
               - 'web/**'
               - '.github/workflows/**'
+            # deploy-bot は functions に加えて firestore の rules / indexes も
+            # デプロイするため、それらの定義ファイルも検知対象に含める。
             bot:
               - 'bot/**'
               - '.github/workflows/**'
+              - 'firebase.json'
+              - '.firebaserc'
+              - 'firestore.rules'
+              - 'firestore.indexes.json'
             deps:
               - 'package*.json'
               - 'package-lock.json'
@@ -295,12 +301,12 @@ jobs:
 
       - name: Deploy to Firebase
         run: |
-          npm install -g firebase-tools@latest
+          npm install -g firebase-tools@15
           firebase deploy --only functions,firestore:rules,firestore:indexes --project "$FIREBASE_PROJECT_ID"
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
-          # 未設定なら .firebaserc の default を使う（空文字を渡すと deploy が落ちるため）
-          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID || 'default' }}
+          # 未設定時のフォールバック（空文字を渡すと deploy が落ちるため）
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID || 'line-kakeibo-0410' }}
 
   # デプロイ後の健全性チェック
   post-deploy-check:
@@ -313,7 +319,10 @@ jobs:
       - name: Health check - Web
         if: needs.deploy-web.result == 'success'
         run: |
-          response=$(curl -s -L -o /dev/null -w "%{http_code}" --max-time 30 https://line-kakeibo.vercel.app/)
+          # curl 自体が失敗すると set -e でここで止まりメッセージが出ないため 000 を割り当てる
+          response=$(curl -s -L -o /dev/null -w "%{http_code}" \
+            --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors \
+            https://line-kakeibo.vercel.app/) || response=000
           if [ "$response" -eq 200 ]; then
             echo "✅ Web app is healthy"
           else
@@ -328,8 +337,10 @@ jobs:
         env:
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID || 'line-kakeibo-0410' }}
         run: |
-          response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 \
-            "https://asia-northeast1-${FIREBASE_PROJECT_ID}.cloudfunctions.net/webhook/health")
+          # デプロイ直後はトラフィック切替中で一時的に落ちうるためリトライする
+          response=$(curl -s -o /dev/null -w "%{http_code}" \
+            --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors \
+            "https://asia-northeast1-${FIREBASE_PROJECT_ID}.cloudfunctions.net/webhook/health") || response=000
           if [ "$response" -eq 200 ]; then
             echo "✅ Bot functions are healthy"
           else

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -69,14 +69,24 @@ jobs:
         cd web
         npm run build
         
-    - name: Deploy Firebase Functions (Production)
-      uses: w9jds/firebase-action@master
+    # 認証は ci-cd.yml と同じサービスアカウント方式に揃える。
+    # 旧構成の FIREBASE_TOKEN（firebase login:ci）は非推奨で、
+    # 手動フォールバックとして使えない状態だった。
+    - name: Authenticate to Google Cloud
+      id: auth
+      uses: google-github-actions/auth@v3
       with:
-        args: deploy --only functions
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+    - name: Deploy Firebase Functions (Production)
+      run: |
+        npm install -g firebase-tools@15
+        firebase deploy --only functions --project "$FIREBASE_PROJECT_ID"
       env:
-        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-        PROJECT_ID: line-kakeibo-0410
-        
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
+        FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID || 'line-kakeibo-0410' }}
+
+
     - name: Deploy to Vercel (Production)
       uses: amondnet/vercel-action@v25
       id: vercel-deploy

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,8 +1,9 @@
 name: Deploy to Production
 
+# master への push では ci-cd.yml（Improved CI/CD Pipeline）がデプロイを担当する。
+# 両方が push で動くと Functions を二重にデプロイするため、こちらは手動実行のみにする。
 on:
-  push:
-    branches: [ master, develop]
+  workflow_dispatch:
 
 env:
   NODE_VERSION: '22'
@@ -22,16 +23,11 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
         
-    - name: Install dependencies (Bot)
-      run: |
-        cd bot
-        npm ci
-        
-    - name: Install dependencies (Web)
-      run: |
-        cd web
-        npm ci
-        
+    # npm workspaces のためルートで一括インストールする。
+    # サブディレクトリの npm ci では依存が解決できず tsc が落ちる。
+    - name: Install dependencies
+      run: npm ci
+
     - name: Lint Bot
       run: |
         cd bot
@@ -59,16 +55,10 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
         
-    - name: Install dependencies (Bot)
-      run: |
-        cd bot
-        npm ci
-        
-    - name: Install dependencies (Web)
-      run: |
-        cd web
-        npm ci
-        
+    # npm workspaces のためルートで一括インストールする。
+    - name: Install dependencies
+      run: npm ci
+
     - name: Build Bot
       run: |
         cd bot


### PR DESCRIPTION
## 📋 変更内容

master への push で失敗し続けている 2 つのデプロイ経路を修正します。

### `ci-cd.yml` の `deploy-bot` — 認証情報が設定されても成功しない状態でした

- `Authenticate to Google Cloud` に `id: auth` が無く、`steps.auth.outputs.credentials_file_path` が空文字に解決されていました。これを `GOOGLE_APPLICATION_CREDENTIALS` に渡していたため、auth アクションが export した正しいパスを**空文字で上書き**していました。
- `firebase deploy` は関数一覧を取得するために `bot/` のコードを実際に読み込みます。このジョブはビルド成果物（`dist`）しか用意しておらず、`firebase-functions` を解決できません。ルートで `npm ci` を追加しました（npm workspaces なので依存はルートへ hoist されます）。
- `FIREBASE_PROJECT_ID` が未設定だと `--project ""` を渡していました。実プロジェクト ID へフォールバックします。
- `firebase-tools` を `@latest` からメジャー固定（`@15`）に変更し、デプロイの再現性を確保しました。

### `ci-cd.yml` の変更検知 — rules 変更がデプロイされませんでした

`deploy-bot` は `firestore:rules,firestore:indexes` もデプロイ対象にしているのに、`paths-filter` の `bot` は `bot/**` とワークフローしか見ていませんでした。ルールだけ変更した push ではジョブがスキップされ、本番に反映されません。`firebase.json` / `.firebaserc` / `firestore.rules` / `firestore.indexes.json` を検知対象に追加しました。

### `ci-cd.yml` の `post-deploy-check` — 存在しない URL を叩いていました

実際に叩いて確認した結果に合わせます。

| チェック対象 | 変更前 | 実測 | 変更後 |
|---|---|---|---|
| Bot | `us-central1-<project>.cloudfunctions.net/health` | 404 | `asia-northeast1-<project>.cloudfunctions.net/webhook/health`（200） |
| Web | `your-app.vercel.app/api/health`（プレースホルダ） | — | `line-kakeibo.vercel.app/`（200） |

`/health` は `webhook` 関数（`asia-northeast1`）が持つ express ルートです。web の `/api/health` は静的エクスポートのため無効化されており GET は 405 を返すので、トップページの応答で生存確認します。

あわせて、`run:` は `set -e` で動くため curl が非 0 終了すると代入の時点でステップが落ち、用意したエラーメッセージに到達しませんでした。`|| response=000` で拾い、デプロイ直後の一時的な失敗に備えてリトライを追加しています。

### `ci-cd.yml` の concurrency — デプロイ中の run がキャンセルされうる

`cancel-in-progress: true` は master への連続 push にも効くため、`firebase deploy` の実行中に run が打ち切られると部分デプロイになります。古い run を捨ててよいのは PR の再 push だけなので、キャンセルを `pull_request` イベントに限定しました。

### `deploy-production.yml` — 二重デプロイと、機能しない認証

`ci-cd.yml` と同じ Functions を push で二重にデプロイする構成でした。手動実行（`workflow_dispatch`）のみに変更します。あわせて以下も修正しました。

- `cd bot && npm ci` が npm workspaces 非対応で毎回 tsc が落ちていたため、ルートの `npm ci` に統一
- Firebase 認証を `w9jds/firebase-action@master` + 非推奨の `FIREBASE_TOKEN` から、`ci-cd.yml` と同じサービスアカウント方式へ統一（手動フォールバックとして機能しない状態だったため。`@master` 参照のサプライチェーンリスクも解消）

## 🎯 目的・背景

PR #142 のマージで走った CI で `deploy-bot` が失敗しました。調査したところ、**同じ失敗はベースコミット `91ad335` でも発生**しており、この PR の変更が原因ではありませんでした。さらに遡ると `deploy-bot` は一度も成功したことがなく（直近の成功 run は全ジョブが skipped）、CI 経由の Firebase デプロイは未成立のままでした。

デプロイ自体は `SETUP.md` / `docs/ARCHITECTURE.md` に記載のとおり手元からの `firebase deploy` で運用されてきたと見られます。

## 🔧 変更種別

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 設定・ツール (Configuration/Tools)

## 🧪 テスト

- [x] 両ワークフローの YAML パースと、全 `run:` ブロックの `bash -n` 構文チェック
- [x] health エンドポイントの実測（bot: 200 / 旧 URL: 404 / web `/api/health`: 405 / web トップ: 200）
- [x] health check の curl を成功・失敗の両方で実行し、失敗時に `000` を拾ってメッセージに到達することを確認
- [x] ルート `package.json` の `workspaces: ["bot", "web"]` と `package-lock.json` の存在を確認
- [x] `firebase-tools` の現行メジャーが 15 であることを確認
- [ ] **`deploy-bot` の通し確認は未実施**（後述の秘密情報が未設定のため実行できません）

## 📱 動作環境

- [x] Bot (Firebase Functions)

## 🔗 関連Issue

- Related to #142

## ⚠️ 注意事項

**この PR だけでは `deploy-bot` は緑になりません。** 根本原因である認証情報の欠落はリポジトリ設定側の問題で、コードでは解消できません。

```
google-github-actions/auth failed with: the GitHub Action workflow must specify
exactly one of "workload_identity_provider" or "credentials_json"!
```

`secrets.GCP_SA_KEY` が未設定（空）です。Settings → Secrets and variables → Actions で以下のいずれかの対応が必要です。

1. **`GCP_SA_KEY` を追加**（現行構成のまま）— Firebase プロジェクトのサービスアカウント JSON をそのまま値にします。`secrets:` 宣言付きの関数をデプロイするため、Cloud Functions / Cloud Run のデプロイ権限に加えて Secret Manager の参照権限も必要です。
2. **Workload Identity Federation へ移行** — 鍵レスで推奨。`credentials_json` を `workload_identity_provider` + `service_account` に置き換えます。

`environment: production-bot` が指定されているため、リポジトリ秘密情報でも Environment 秘密情報でも構いません。設定後にこのワークフローを再実行すれば、上記の修正込みでデプロイが走ります。

なお `deploy-production.yml` を手動限定にしても失われる機能はありません。同ワークフローは全 run が失敗しており、Vercel の本番デプロイは Vercel 側の GitHub 連携が担当しています。副次的な効果として、従来 `develop` への push でも本番へデプロイしようとしていた挙動が解消されます。

## ✅ チェックリスト

- [x] コードレビューを受けた
- [ ] **必要な環境変数・設定は更新済み** ← `GCP_SA_KEY` の登録が必要です

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * デプロイ時のヘルスチェックを実際のエンドポイントに対応させ、リトライやタイムアウト処理を追加しました。
  * WebおよびBotのデプロイ安定性を向上しました。
* **運用**
  * 本番デプロイを手動実行に変更しました。
  * 更新時の不要な処理を抑制し、デプロイの信頼性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->