### PR TITLE
fix(ci): 常に失敗する deploy-web を削除しデプロイ担当を明確にする

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -159,13 +159,16 @@ jobs:
         run: |
           npm test --if-present || echo "::notice::No tests configured for ${{ matrix.app }}"
           
+      # 成果物を使うのは deploy-bot だけ（firebase deploy が bot/dist を同梱する）。
+      # web は Vercel の Git 連携がソースからビルドするため成果物を必要としない。
+      # なお .next は隠しディレクトリで upload-artifact v4 の既定では除外されるため、
+      # 以前の web-build は中身が空になり deploy-web のダウンロードが失敗していた。
       - name: Upload build artifacts
+        if: matrix.app == 'bot'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.app }}-build
-          path: |
-            ${{ matrix.app }}/dist
-            ${{ matrix.app }}/.next
+          name: bot-build
+          path: bot/dist
           retention-days: 1
 
   # セキュリティチェック（並列実行）
@@ -213,57 +216,12 @@ jobs:
         if: steps.init-codeql.outcome == 'success'
         uses: github/codeql-action/analyze@v3
 
-  # Webアプリデプロイ（Vercel）
-  deploy-web:
-    runs-on: ubuntu-latest
-    needs: [build-and-test, lint, changes]
-    if: |
-      github.ref == 'refs/heads/master' && 
-      github.event_name == 'push' &&
-      needs.changes.outputs.web == 'true'
-    environment:
-      name: production-web
-      url: ${{ steps.deploy.outputs.url }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          
-      - name: Download build artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: web-build
-          path: web/
-          
-      - name: Deploy to Vercel
-        id: deploy
-        run: |
-          npm install -g vercel@latest
-          cd web
-          vercel pull --environment=production --token="${{ secrets.VERCEL_TOKEN }}" --yes --project line-kakeibo
-          DEPLOYMENT_URL=$(vercel --prod --token="${{ secrets.VERCEL_TOKEN }}" --yes --project line-kakeibo)
-          echo "url=${DEPLOYMENT_URL}" >> $GITHUB_OUTPUT
-          echo "Deployed to: ${DEPLOYMENT_URL}"
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          
-      - name: Comment deployment URL
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '🚀 Web app deployed to: ${{ steps.deploy.outputs.url }}'
-            })
+  # Web（Vercel）のデプロイジョブはここには無い。
+  # Vercel へのデプロイは Vercel の Git 連携（GitHub App）がネイティブに実行する。
+  # 以前ここにあった deploy-web は vercel CLI で二重にデプロイしようとするもので、
+  # vercel-deploy.yml が同じ理由で no-op 化されたのと同じ構成だった。加えて
+  # web-build 成果物が常に空（.next は隠しディレクトリで除外される）だったため、
+  # ダウンロード段階で必ず失敗していた。詳細は .github/workflows/vercel-deploy.yml 参照。
 
   # Bot/Functions デプロイ（Firebase）
   deploy-bot:
@@ -314,25 +272,9 @@ jobs:
   # デプロイ後の健全性チェック
   post-deploy-check:
     runs-on: ubuntu-latest
-    needs: [deploy-web, deploy-bot]
-    if: always() && (needs.deploy-web.result == 'success' || needs.deploy-bot.result == 'success')
+    needs: [deploy-bot]
+    if: always() && needs.deploy-bot.result == 'success'
     steps:
-      # web の /api/health は静的エクスポートのため無効化されている（GETは405）。
-      # 代わりにトップページの応答でデプロイの生存を確認する。
-      - name: Health check - Web
-        if: needs.deploy-web.result == 'success'
-        run: |
-          # curl 自体が失敗すると set -e でここで止まりメッセージが出ないため 000 を割り当てる
-          response=$(curl -s -L -o /dev/null -w "%{http_code}" \
-            --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors \
-            https://line-kakeibo.vercel.app/) || response=000
-          if [ "$response" -eq 200 ]; then
-            echo "✅ Web app is healthy"
-          else
-            echo "❌ Web app health check failed (HTTP $response)"
-            exit 1
-          fi
-
       # /health は webhook 関数（asia-northeast1）が持つ express ルート。
       # 旧URL（us-central1 直下の /health）は存在せず 404 になる。
       - name: Health check - Bot
@@ -358,7 +300,6 @@ jobs:
           status: ${{ job.status }}
           text: |
             Deployment Status:
-            - Web: ${{ needs.deploy-web.result }}
             - Bot: ${{ needs.deploy-bot.result }}
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
         continue-on-error: true
@@ -366,11 +307,11 @@ jobs:
   # リリースノート生成（オプション）
   release-notes:
     runs-on: ubuntu-latest
-    needs: [deploy-web, deploy-bot]
+    needs: [deploy-bot]
     if: |
-      github.ref == 'refs/heads/master' && 
+      github.ref == 'refs/heads/master' &&
       github.event_name == 'push' &&
-      (needs.deploy-web.result == 'success' || needs.deploy-bot.result == 'success')
+      needs.deploy-bot.result == 'success'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -154,11 +154,14 @@ jobs:
         working-directory: ./${{ matrix.app }}
         run: npm run build
         
+      # --if-present は test スクリプトが無ければ 0 で終わるので、スクリプト未定義の
+      # ワークスペースでも失敗しない。`|| echo` を付けるとテストが落ちても緑になり、
+      # テストを追加しても意味がなくなるため付けない。
       - name: Run tests
         working-directory: ./${{ matrix.app }}
-        run: |
-          npm test --if-present || echo "::notice::No tests configured for ${{ matrix.app }}"
-          
+        run: npm test --if-present
+
+
       # 成果物を使うのは deploy-bot だけ（firebase deploy が bot/dist を同梱する）。
       # web は Vercel の Git 連携がソースからビルドするため成果物を必要としない。
       # なお .next は隠しディレクトリで upload-artifact v4 の既定では除外されるため、

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -169,7 +169,11 @@ LINEのリンク(?lineId=xxx) → Next.js（クライアント）
 ## 7. デプロイ・CI/CD
 
 - **ブランチ運用**: `feature/* → develop → master`（`DEPLOYMENT_SETUP.md`）。develop = Vercel プレビュー、master = 本番
-- **GitHub Actions**: `deploy-develop.yml` / `deploy-production.yml` / `pr-checks.yml`。Secrets: `FIREBASE_SERVICE_ACCOUNT_*`, `FIREBASE_TOKEN`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
+- **デプロイの担当**:
+  - Web（Vercel）→ **Vercel の Git 連携が実行**する。GitHub Actions 側にデプロイジョブは持たない（`vercel-deploy.yml` は意図的に no-op）
+  - Bot / Firestore ルール・インデックス → `ci-cd.yml` の `deploy-bot`（master への push のみ）
+- **`deploy-bot` の前提**: リポジトリ（または `production-bot` Environment）に **`GCP_SA_KEY`** が必要。値は Firebase プロジェクトのサービスアカウント JSON。`onRequest({ secrets: [...] })` を使う関数をデプロイするため、Cloud Functions / Cloud Run のデプロイ権限に加えて **Secret Manager の参照権限**も要る。未設定だと `google-github-actions/auth` が `must specify exactly one of "workload_identity_provider" or "credentials_json"` で失敗する
+- **GitHub Actions**: `ci-cd.yml`（本線）/ `pr-checks.yml` / `deploy-develop.yml`。`deploy-production.yml` は `ci-cd.yml` と重複するため手動実行（`workflow_dispatch`）専用。Secrets: `GCP_SA_KEY`, `FIREBASE_PROJECT_ID`（未設定時は `.firebaserc` の値にフォールバック）
 - **手動スクリプト**: `web/deploy-vercel.sh`（lint→build→vercel --prod）、`deploy-bot.sh`（firebase deploy --only functions）、`deploy-all.sh`
 - ローカル開発: `web` は `npm run dev`（:3000）、`bot` は `ts-node-dev`（:8080）＋ Firebase Emulator（`NEXT_PUBLIC_USE_FIREBASE_EMULATOR`）
 


### PR DESCRIPTION
## 📋 変更内容

#147 のマージ後の master run で `deploy-web` が失敗しました。

```
Unable to download artifact(s): Artifact not found for name: web-build
```

原因は `actions/upload-artifact@v4` が**隠しファイルを既定で除外する**ことです。web のビルド成果物は `.next` だけで、もう一方に指定していた `web/dist` は存在しません。結果として `web-build` は中身が空のまま作られず、`deploy-web` のダウンロードが必ず失敗していました。bot 側は `bot/dist`（隠しでない）なので影響を受けていません。

ただし `deploy-web` は**そもそも不要**でした。

- 中身は `vercel pull` + `vercel --prod` による CLI デプロイで、これは `vercel-deploy.yml` が「Vercel の Git 連携に一本化した」として意図的に no-op 化したのと同じ方式です（同ファイル冒頭のコメント参照）
- `vercel --prod` は `--prebuilt` を付けない限りソースからビルドするため、ダウンロードした `.next` は**そもそも使われていません**
- master の run 履歴を見る限り、このジョブが成功したことはありません

そこでジョブごと削除し、Vercel = Git 連携、Bot = `ci-cd.yml` の `deploy-bot`、という担当分けを明示しました。

- `deploy-web` を削除し、`post-deploy-check` / `release-notes` の `needs` を `deploy-bot` のみに更新
- 参照先が消えた web の health チェックステップと Slack 通知の行を削除
- 成果物のアップロードを bot のみに限定（利用者は `deploy-bot` だけのため）
- `docs/ARCHITECTURE.md` にデプロイ担当と `GCP_SA_KEY` の必要権限を明記

## 🎯 目的・背景

#147 は `.github/workflows/**` を変更したため、変更検知の `web` フィルタにも一致して `deploy-web` が起動し、この積年の失敗が表面化しました。#147 が壊したわけではなく、web を変更する push では以前から同じ失敗が起きていました。

あわせて、前回のレビューで挙がった残りの指摘にも対応しています。

| 指摘 | 対応 |
|---|---|
| `GCP_SA_KEY` の SA に Secret Manager 権限が必要（運用メモ） | `docs/ARCHITECTURE.md` に明記 |
| `deploy-web` の `vercel pull --project` は現行 CLI で失敗する可能性 | **誤検知**。Vercel CLI 58.9.1 で `pull` / `deploy` とも `--project <NAME_OR_ID>` をサポートしていることを確認。ただし本 PR でジョブごと削除するため論点自体が消滅 |
| `npm ci -w bot --include-workspace-root` で短縮できる | 見送り。`deploy-bot` はまだ一度も通し実行できておらず、数十秒の短縮のために未検証のデプロイ経路へインストール範囲の変更を持ち込む利得が薄いため |
| bot 単体の lockfile を用意する | 見送り。workspaces で 2 つ目の lockfile を持つとルート側とドリフトし、かえって「テスト済みバージョンと違うものが入る」リスクが増えるため |

## 🔧 変更種別

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 設定・ツール (Configuration/Tools)
- [x] 📝 ドキュメント更新 (Documentation)

## 🧪 テスト

- [x] YAML パースと全 `run:` ブロックの `bash -n` 構文チェック
- [x] `deploy-web` / `web-build` / `production-web` への参照が残っていないことを確認（コメントを除く）
- [x] ジョブ依存グラフの整合を確認（`post-deploy-check` / `release-notes` の `needs` が `deploy-bot` のみ）
- [x] Vercel CLI 58.9.1 の `pull --help` / `deploy --help` で `--project` の実在を確認
- [x] #147 マージ後の master run で、新設した `Install dependencies`（`npm ci`）が成功し、失敗が認証ステップのみであることを確認（回帰なし）

## 📱 動作環境

- [x] Bot (Firebase Functions)
- [x] Web (Vercel) — デプロイ経路の整理のみ。Vercel Git 連携の挙動は不変

## 🔗 関連Issue

- Related to #147

## ⚠️ 注意事項

この PR をマージしても `deploy-bot` は緑になりません。`secrets.GCP_SA_KEY` の登録が別途必要で、これはリポジトリ設定側の作業です（詳細は #147 および `docs/ARCHITECTURE.md`）。本 PR で解消されるのは `deploy-web` 由来の失敗だけです。

---
_Generated by [Claude Code](https://claude.ai/code/session_014UtWrjbUbA8CqoFRvRWZYW)_