### PR TITLE
fix(bot): Gmail 取り込みの取りこぼしを塞ぐ

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "echo 'Lint check passed for bot'",
-    "smoke": "npm run build && node scripts/smoke-expense-card.js && node scripts/smoke-text-parser.js",
+    "smoke": "npm run build && node scripts/smoke-expense-card.js && node scripts/smoke-text-parser.js && node scripts/smoke-gmail-parse.js",
     "test": "npm run smoke",
     "predeploy": "npm run build",
     "deploy": "npm run build && firebase deploy --only functions",

--- a/bot/scripts/smoke-gmail-parse.js
+++ b/bot/scripts/smoke-gmail-parse.js
@@ -1,0 +1,66 @@
+/**
+ * カード利用通知メールのパースと日付整形のスモークテスト
+ *
+ *   node bot/scripts/smoke-gmail-parse.js
+ */
+const { parseSMBCCardEmail } = require('../dist/gmail/parser');
+const { toJSTDateString, formatJST } = require('../dist/time');
+
+let failed = 0;
+
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`  ok   ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL ${name}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+function buildBody(dateTime, merchant, amount) {
+  return [
+    '【ご利用のお知らせ】',
+    `ご利用日時：${dateTime}`,
+    `ご利用店名：${merchant}`,
+    `ご利用金額：${amount}円`,
+    'カード番号（下4桁）：1234',
+    '三井住友ゴールドＶＩＳＡ（ＮＬ）',
+  ].join('\n');
+}
+
+console.log('parseSMBCCardEmail');
+
+const evening = parseSMBCCardEmail('msg-1', buildBody('2026/03/14 19:20', 'イオン〇〇店', '3,240'));
+check('金額・店舗名を拾う', evening && evening.amount === 3240 && evening.merchant === 'イオン〇〇店', JSON.stringify(evening));
+check('利用日時をJSTの実時刻として読む', evening && evening.usedAt.toISOString() === '2026-03-14T10:20:00.000Z',
+  evening && evening.usedAt.toISOString());
+check('保存する日付は利用日と一致する', evening && toJSTDateString(evening.usedAt) === '2026-03-14',
+  evening && toJSTDateString(evening.usedAt));
+
+// JST 深夜〜早朝。コンテナのTZに引きずられると前日になる区間
+const midnight = parseSMBCCardEmail('msg-2', buildBody('2026/09/01 00:30', 'コンビニ', '901'));
+check('JST 0時台でも当日の日付になる', midnight && toJSTDateString(midnight.usedAt) === '2026-09-01',
+  midnight && toJSTDateString(midnight.usedAt));
+check('通知の M/D 表示も当日', midnight && formatJST(midnight.usedAt, 'M/D') === '9/1',
+  midnight && formatJST(midnight.usedAt, 'M/D'));
+
+// 別書式（◇利用先 / ◇利用日）
+const altFormat = parseSMBCCardEmail('msg-3', [
+  '◇利用日：2026/03/14 19:20',
+  '◇利用先：NIKUNOHANAMASA',
+  '◇利用金額：901円',
+].join('\n'));
+check('◇ 書式も読める', altFormat && altFormat.amount === 901 && altFormat.merchant === 'NIKUNOHANAMASA', JSON.stringify(altFormat));
+
+// 時刻の無い通知
+const dateOnly = parseSMBCCardEmail('msg-4', buildBody('2026/03/14', 'スーパー', '500'));
+check('時刻が無ければ 00:00 として当日になる', dateOnly && toJSTDateString(dateOnly.usedAt) === '2026-03-14',
+  dateOnly && toJSTDateString(dateOnly.usedAt));
+
+check('金額が無いメールは null', parseSMBCCardEmail('msg-5', 'ご利用日時：2026/03/14 19:20') === null);
+
+if (failed > 0) {
+  console.error(`\n${failed} check(s) failed`);
+  process.exit(1);
+}
+console.log('\nAll checks passed');

--- a/bot/src/gmail/handler.ts
+++ b/bot/src/gmail/handler.ts
@@ -5,7 +5,8 @@
  * 三井住友カードの利用通知を処理して支出を自動登録
  */
 
-import dayjs from 'dayjs';
+import { getFirestore, FieldValue, Timestamp } from 'firebase-admin/firestore';
+import { formatJST, toJSTDateString } from '../time';
 import { getGmailClient } from './auth';
 import { getWatchState, updateHistoryId } from './watch';
 import {
@@ -58,8 +59,59 @@ export async function handleGmailPubSub(data: string): Promise<void> {
 }
 
 /**
+ * 同じメッセージで諦めるまでの試行回数
+ *
+ * 恒久的に処理できないメール（パースできない等）で historyId が永久に止まるのを防ぐ。
+ */
+const MAX_MESSAGE_ATTEMPTS = 3;
+
+/** 失敗したメッセージの記録。`system/gmailFailures` に messageId ごとの試行回数を持つ */
+async function recordMessageFailure(messageId: string, error: unknown): Promise<number> {
+  const db = getFirestore();
+  const ref = db.collection('system').doc('gmailFailures');
+
+  return db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(ref);
+    const failures = (snapshot.exists ? snapshot.data() : {}) || {};
+    const previous = (failures[messageId]?.attempts as number | undefined) ?? 0;
+    const attempts = previous + 1;
+
+    transaction.set(
+      ref,
+      {
+        [messageId]: {
+          attempts,
+          lastError: String((error as Error)?.message ?? error).slice(0, 500),
+          lastFailedAt: Timestamp.now(),
+        },
+      },
+      { merge: true }
+    );
+
+    return attempts;
+  });
+}
+
+/** 処理できたメッセージを失敗記録から外す */
+async function clearMessageFailure(messageId: string): Promise<void> {
+  const db = getFirestore();
+  await db
+    .collection('system')
+    .doc('gmailFailures')
+    .set({ [messageId]: FieldValue.delete() }, { merge: true })
+    .catch((error) => console.warn(`Failed to clear failure record for ${messageId}:`, error));
+}
+
+/**
  * 新着メールを取得して処理
  * ページネーション対応：全ページを処理してからhistoryIdを更新
+ *
+ * 1通でも処理に失敗したら historyId を進めない。以前は個別の失敗を握り潰したまま
+ * historyId を進めていたため、一過性のエラー（Gemini/LINE/Firestore の失敗や
+ * トランザクション競合）で落ちたカード利用が**二度と再処理されず消えていた**。
+ * Pub/Sub の再送に委ねる（重複は gmailMessageId で弾かれる）。
+ * ただし同じメッセージが MAX_MESSAGE_ATTEMPTS 回失敗したら、その1通は諦めて先へ進む
+ * （恒久的に処理できない1通で以降の取り込みが止まらないようにする）。
  */
 async function processNewEmails(newHistoryId: string): Promise<void> {
   const gmail = await getGmailClient();
@@ -72,6 +124,8 @@ async function processNewEmails(newHistoryId: string): Promise<void> {
 
   const startHistoryId = watchState.historyId;
   const processedMessageIds: string[] = [];
+  const retryableFailures: string[] = [];
+  const abandonedFailures: string[] = [];
 
   try {
     let pageToken: string | undefined;
@@ -98,12 +152,42 @@ async function processNewEmails(newHistoryId: string): Promise<void> {
           if (processedMessageIds.includes(messageId)) continue;
           processedMessageIds.push(messageId);
 
-          await processMessage(gmail, messageId);
+          try {
+            await processMessage(gmail, messageId);
+            await clearMessageFailure(messageId);
+          } catch (messageError) {
+            const attempts = await recordMessageFailure(messageId, messageError);
+            console.error(
+              `Failed to process message ${messageId} (attempt ${attempts}/${MAX_MESSAGE_ATTEMPTS}):`,
+              messageError
+            );
+            if (attempts >= MAX_MESSAGE_ATTEMPTS) {
+              abandonedFailures.push(messageId);
+            } else {
+              retryableFailures.push(messageId);
+            }
+          }
         }
       }
 
       pageToken = historyResponse.data.nextPageToken || undefined;
     } while (pageToken);
+
+    if (abandonedFailures.length > 0) {
+      console.error(
+        `Giving up on ${abandonedFailures.length} message(s) after ${MAX_MESSAGE_ATTEMPTS} attempts: ` +
+          `${abandonedFailures.join(', ')}. ` +
+          'Re-run manually with POST /gmail/force-process/:messageId after fixing the cause.'
+      );
+    }
+
+    if (retryableFailures.length > 0) {
+      // historyId を進めずに投げ直す。Pub/Sub が再送し、次回この範囲をやり直す。
+      throw new Error(
+        `${retryableFailures.length} message(s) failed, keeping historyId at ${startHistoryId} for retry: ` +
+          retryableFailures.join(', ')
+      );
+    }
 
     // 全ページ処理完了後にhistoryIdを更新
     await updateHistoryId(newHistoryId);
@@ -111,7 +195,10 @@ async function processNewEmails(newHistoryId: string): Promise<void> {
   } catch (error: any) {
     // historyIdが古すぎる場合は最新に更新
     if (error.code === 404) {
-      console.warn('History ID too old, updating to latest');
+      console.error(
+        `History ID ${startHistoryId} is too old (Gmail keeps ~1 week). ` +
+          `Skipping to ${newHistoryId}; mail in between is NOT imported.`
+      );
       await updateHistoryId(newHistoryId);
     } else {
       throw error;
@@ -175,7 +262,7 @@ async function processMessage(gmail: any, messageId: string): Promise<void> {
       lineId: GMAIL_SYSTEM_LINE_ID, // システムユーザーとして登録
       amount: parsed.amount,
       description: parsed.merchant,
-      date: dayjs(parsed.usedAt).format('YYYY-MM-DD'),
+      date: toJSTDateString(parsed.usedAt),
       category,
       confirmed: false, // 未確認状態
       includeInTotal: true, // Gmail自動取得は基本的に会計に含める
@@ -206,7 +293,7 @@ async function processMessage(gmail: any, messageId: string): Promise<void> {
         amount: parsed.amount,
         category,
         categoryEmoji: getCategoryEmoji(category),
-        date: dayjs(parsed.usedAt).format('M/D'),
+        date: formatJST(parsed.usedAt, 'M/D'),
         // 保存時の値と揃える（Gmail自動取得は未確認でも集計に入る）
         status: 'pending',
         includeInTotal: true,
@@ -216,8 +303,10 @@ async function processMessage(gmail: any, messageId: string): Promise<void> {
       console.warn('LINE_GROUP_ID not configured, skipping notification');
     }
   } catch (error) {
+    // 呼び出し元（processNewEmails）が試行回数を記録し、historyId を進めるかを決める。
+    // ここで握り潰すと、失敗したメールが再処理されないまま historyId だけ進んでしまう。
     console.error(`Failed to process message ${messageId}:`, error);
-    // 個別のメッセージ処理エラーは全体を止めない
+    throw error;
   }
 }
 
@@ -281,7 +370,7 @@ export async function processLatestEmail(): Promise<{
         lineId: GMAIL_SYSTEM_LINE_ID,
         amount: parsed.amount,
         description: parsed.merchant,
-        date: dayjs(parsed.usedAt).format('YYYY-MM-DD'),
+        date: toJSTDateString(parsed.usedAt),
         category: categoryResult.category || 'その他',
         confirmed: false,
         includeInTotal: true, // Gmail自動取得は基本的に会計に含める
@@ -394,7 +483,7 @@ export async function forceProcessMessage(messageId: string): Promise<{
       lineId: GMAIL_SYSTEM_LINE_ID,
       amount: parsed.amount,
       description: parsed.merchant,
-      date: dayjs(parsed.usedAt).format('YYYY-MM-DD'),
+      date: toJSTDateString(parsed.usedAt),
       category,
       confirmed: false,
       includeInTotal: true, // Gmail自動取得は基本的に会計に含める
@@ -428,7 +517,7 @@ export async function forceProcessMessage(messageId: string): Promise<{
         amount: parsed.amount,
         category,
         categoryEmoji: getCategoryEmoji(category),
-        date: dayjs(parsed.usedAt).format('M/D'),
+        date: formatJST(parsed.usedAt, 'M/D'),
         // 保存時の値と揃える（Gmail自動取得は未確認でも集計に入る）
         status: 'pending',
         includeInTotal: true,

--- a/bot/src/gmail/parser.ts
+++ b/bot/src/gmail/parser.ts
@@ -7,7 +7,7 @@
 
 import { ParsedCardNotification, SMBC_CARD_FILTER } from './types';
 import { getFirestore } from 'firebase-admin/firestore';
-import dayjs from 'dayjs';
+import { parseJSTWallClock, toJSTDateString } from '../time';
 
 /**
  * メールが三井住友ゴールドVISA（NL）の利用通知かどうか判定
@@ -84,7 +84,9 @@ export function parseSMBCCardEmail(
     if (dateMatch) {
       const dateStr = dateMatch[1];
       const timeStr = dateMatch[2] || '00:00';
-      usedAt = new Date(`${dateStr.replace(/\//g, '-')} ${timeStr}`);
+      // メール本文の日時は JST の壁時計表記。コンテナのTZ（本番は UTC）で
+      // 解釈すると9時間ずれた瞬間になるため、JST として読む。
+      usedAt = parseJSTWallClock(dateStr.replace(/\//g, '-'), timeStr);
     } else {
       // 日時が見つからない場合は現在時刻を使用
       usedAt = new Date();
@@ -235,8 +237,8 @@ export async function isDuplicateByTimestamp(
   amount: number
 ): Promise<boolean> {
   const db = getFirestore();
-  // 保存時と同じくdayjsを使用してローカルタイムゾーンで日付を正規化
-  const date = dayjs(usedAt).format('YYYY-MM-DD');
+  // 保存時（handler.ts）と同じ整形にそろえる。片方だけ変えると重複判定が壊れる
+  const date = toJSTDateString(usedAt);
 
   // 同じ日付で同じ金額のGmail自動取得の支出のみを検索
   const snapshot = await db

--- a/bot/src/gmail/watch.ts
+++ b/bot/src/gmail/watch.ts
@@ -108,14 +108,37 @@ export async function getWatchState(): Promise<GmailWatchState | null> {
   };
 }
 
+/** historyId は uint64 の文字列。桁があふれるので BigInt で比較する */
+function isNewerHistoryId(candidate: string, current: string): boolean {
+  try {
+    return BigInt(candidate) > BigInt(current);
+  } catch {
+    // 数値として読めない値が入っていたら、比較を諦めて更新を許す
+    return true;
+  }
+}
+
 /**
- * historyIdを更新
+ * historyIdを更新（前進のみ）
+ *
+ * Pub/Sub は at-least-once で順序保証が無いため、古い通知が後着すると historyId が
+ * 巻き戻る。巻き戻ると次回の `history.list` が既知の範囲を取り直すことになり、
+ * 404（履歴が古すぎる）と重なったときに取りこぼす。必ず新しい方を残す。
  */
 export async function updateHistoryId(historyId: string): Promise<void> {
   const db = getFirestore();
-  await db.collection('system').doc('gmailState').update({
-    historyId,
-    updatedAt: Timestamp.now(),
+  const ref = db.collection('system').doc('gmailState');
+
+  await db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(ref);
+    const current = snapshot.exists ? (snapshot.data()?.historyId as string | undefined) : undefined;
+
+    if (current && !isNewerHistoryId(historyId, current)) {
+      console.log(`Skipping historyId rollback: current=${current}, incoming=${historyId}`);
+      return;
+    }
+
+    transaction.set(ref, { historyId, updatedAt: Timestamp.now() }, { merge: true });
   });
 }
 

--- a/bot/src/time.ts
+++ b/bot/src/time.ts
@@ -29,3 +29,24 @@ export function todayJST(): string {
 }
 
 export { dayjs };
+
+/** 任意の日時を JST の YYYY-MM-DD にする */
+export function toJSTDateString(value: Date | string): string {
+  return dayjs(value).tz(JST).format('YYYY-MM-DD');
+}
+
+/** 任意の日時を JST で書式化する */
+export function formatJST(value: Date | string, template: string): string {
+  return dayjs(value).tz(JST).format(template);
+}
+
+/**
+ * 「2026/3/14 19:20」のような JST の壁時計表記を Date にする
+ *
+ * `new Date('2026-03-14 19:20')` はコンテナのTZ（本番は UTC）で解釈されるため、
+ * JST の表記をそのまま渡すと実時刻より9時間ずれた瞬間になる。
+ */
+export function parseJSTWallClock(dateStr: string, timeStr: string): Date {
+  const parsed = dayjs.tz(`${dateStr} ${timeStr}`, 'YYYY-M-D H:mm', JST);
+  return parsed.isValid() ? parsed.toDate() : new Date();
+}


### PR DESCRIPTION
closes #151

#150 の調査中に見つけた、カード利用メールが**無言で欠落する**経路を塞ぎます。

## 1. 失敗を握り潰したまま historyId を進めていた（本命）

`processMessage` は個別エラーを catch して黙って戻る一方、`processNewEmails` は必ず `updateHistoryId` を実行していました。つまり **一過性の失敗で落ちた1通は二度と再処理されず、支出が永久に消えます**。連続した利用通知は `saveGmailExpenseAtomic` の重複チェッククエリ（date + amount + inputSource）が重なるためトランザクション競合が起きやすく、これを踏みやすい構造でした。

- 1通でも失敗したら **historyId を進めずに投げ直す** → Pub/Sub が再送（重複は `gmailMessageId` で弾かれるので二重登録しません）
- 同じメッセージが **3回**失敗したら、その1通だけ諦めて先へ進む（恒久的に処理できない1通で以降の取り込みが止まらないようにする）
- 失敗は `system/gmailFailures` に `{attempts, lastError, lastFailedAt}` で記録。原因を直したら既存の `POST /gmail/force-process/:messageId` で個別に再処理できます

## 2. historyId が巻き戻りうる

Pub/Sub は at-least-once かつ順序保証が無いため、古い通知が後着すると `updateHistoryId` の無条件上書きで historyId が戻ります。トランザクションで **前進のみ**に変更（uint64 なので BigInt 比較）。

## 3. 履歴が古すぎる場合（404）の握り潰し

間のメールを捨てていることがログから読み取れなかったので、警告として明示します（Gmail の history 保持は約1週間）。

## 4. Gmail 側の日時解釈を JST 固定に

メール本文の `2026/03/14 19:20` を `new Date()` に渡すとコンテナの TZ（本番は UTC）で解釈され、保存される `usedAt` が**実時刻より9時間ずれて**いました。保存する `date` 文字列は整形側も同じ TZ だったため偶然一致していましたが、**TZ が変わった瞬間に全日付がずれる**作りです。パース・整形・重複判定を同時に JST へ揃えました。

- `date` 文字列は現行と**完全に同一**（4パターンで実測確認済み）。既存データの移行は不要
- 唯一の差分は `usedAt` が正しい瞬間になること。デプロイ前後をまたいで**同一取引の別メール**が届いた場合のみ、`usedAt` ±1分の重複判定（ルール2）が効かない可能性があります。`gmailMessageId` による判定（ルール1）は従来どおり有効です

## 検証

`npm -w bot run smoke` に Gmail パースのケースを追加し、**TZ=UTC / Asia/Tokyo / America/Los_Angeles** の3通りで全緑。JST 0時台の利用が当日の日付になること、`◇利用日` 書式、時刻なし通知、金額なしメールの null 返しを含みます。

## デプロイ

マージ後、`gmailPubSubHandler` と `api` の手動デプロイが必要です（`GCP_SA_KEY` 未設定の既知問題）。