### PR TITLE
feat(auth): LINE(LIFF)ログイン + Firebase カスタムトークン認証を導入(URL lineId 信頼を廃止)

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,0 +1,36 @@
+# Bot (LINE Messaging API / Firebase Functions) environment variables
+# Copy to bot/.env (or bot/.env.local). Secrets are NEVER committed; in
+# production these are provided via Firebase Secret Manager (function `secrets`).
+
+# --- LINE Messaging API (bot channel) ---
+LINE_CHANNEL_SECRET=your-line-channel-secret
+LINE_CHANNEL_TOKEN=your-line-channel-access-token
+LINE_GROUP_ID=
+DEFAULT_GROUP_ID=
+
+# --- LINE Login (LIFF) channel ---
+# Channel ID of the LINE Login channel backing the LIFF app. Used by the
+# POST /auth/line endpoint to verify LIFF ID tokens against
+# https://api.line.me/oauth2/v2.1/verify (aud must equal this value).
+LINE_LIFF_CHANNEL_ID=your-line-login-channel-id
+
+# Allowed web origins for the /auth/line CORS response (comma-separated).
+# Defaults to https://line-kakeibo.vercel.app,http://localhost:3000 plus
+# line-kakeibo*.vercel.app preview deployments. Override only if needed.
+# WEB_ORIGINS=https://line-kakeibo.vercel.app,http://localhost:3000
+
+# --- Admin / integrations ---
+ADMIN_SECRET=your-admin-secret
+GEMINI_API_KEY=your-gemini-api-key
+GITHUB_TOKEN=your-github-token
+
+# --- Gmail auto-import (OAuth2) ---
+GMAIL_CLIENT_ID=your-gmail-oauth-client-id
+GMAIL_CLIENT_SECRET=your-gmail-oauth-client-secret
+GMAIL_REDIRECT_URI=
+
+# --- Firebase Admin ---
+FIREBASE_PROJECT_ID=line-kakeibo-0410
+# Local: path to a service-account JSON. Production: FIREBASE_SA_BASE64.
+GOOGLE_APPLICATION_CREDENTIALS=
+FIREBASE_SA_BASE64=

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -39,7 +39,8 @@ import {
 import { getCategoryEmoji } from "./gmail/types";
 import { parseTextExpense } from "./textParser";
 import { nowJST } from "./time";
-import { resolveAppUidForExpense } from "./linkUserResolver";
+import { resolveAppUidForExpense, getOrCreateAppUidForLineId } from "./linkUserResolver";
+import { getAuth } from "firebase-admin/auth";
 import { getClassificationStats, classifyExpenseWithGemini, isGeminiAvailable, findCategoryWithGemini } from "./geminiCategoryClassifier";
 import { createIssueFromFeedback } from "./issueCreator";
 // Money Forward Me Import
@@ -1756,17 +1757,160 @@ gmailRouter.post("/force-process/:messageId", adminApiLimiter as any, requireAdm
   }
 });
 
+// ============================================
+// LIFF ログイン → Firebase カスタムトークン発行
+// ============================================
+//
+// Web(LIFF) から受け取った LINE ID トークンを LINE の verify API で検証し、
+// 検証済みの LINE userId(sub) に対応する appUid で Firebase カスタムトークンを発行する。
+// これにより Web は「URL の lineId を信用する」旧方式をやめ、
+// auth.currentUser.uid = appUid / claims.lineId = 検証済み LINE userId で本人特定できる。
+const authRouter = express.Router();
+
+// CORS: Web オリジンのみ許可。既定は本番 Vercel と localhost。
+// 追加/変更は環境変数 WEB_ORIGINS（カンマ区切り）で上書き可能。
+const WEB_ORIGIN_ALLOWLIST = (
+  process.env.WEB_ORIGINS || "https://line-kakeibo.vercel.app,http://localhost:3000"
+)
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const isAllowedWebOrigin = (origin?: string): boolean => {
+  if (!origin) return false;
+  if (WEB_ORIGIN_ALLOWLIST.includes(origin)) return true;
+  // このプロジェクトの Vercel プレビュー(line-kakeibo*.vercel.app)も許可
+  return /^https:\/\/line-kakeibo[a-z0-9-]*\.vercel\.app$/.test(origin);
+};
+
+const authCors = (req: Request, res: Response, next: express.NextFunction) => {
+  const origin = req.headers.origin as string | undefined;
+  if (isAllowedWebOrigin(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin as string);
+    res.setHeader("Vary", "Origin");
+    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    res.setHeader("Access-Control-Max-Age", "3600");
+  }
+  if (req.method === "OPTIONS") {
+    return res.status(204).end();
+  }
+  return next();
+};
+
+authRouter.use(authCors);
+
+// 認証系のレート制限（総当り抑止）
+const authLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const LINE_VERIFY_URL = "https://api.line.me/oauth2/v2.1/verify";
+
+/**
+ * POST /auth/line
+ * Body: { idToken: string }  … LIFF の ID トークン
+ * Response: { customToken: string }  … Firebase カスタムトークン
+ * 失敗時は 401 { error }。生のトークンは絶対にログ出力しない。
+ */
+authRouter.post("/line", authLimiter as any, async (req: Request, res: Response) => {
+  try {
+    const idToken = (req.body && req.body.idToken) as unknown;
+    if (!idToken || typeof idToken !== "string") {
+      return res.status(400).json({ error: "idToken is required" });
+    }
+
+    const channelId = process.env.LINE_LIFF_CHANNEL_ID;
+    if (!channelId) {
+      console.error("LINE_LIFF_CHANNEL_ID is not configured");
+      return res.status(503).json({ error: "Auth is not configured" });
+    }
+
+    // LINE で ID トークンを検証（AbortController でタイムアウト）
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    let verifyData: {
+      iss?: string;
+      sub?: string;
+      aud?: string | string[];
+      exp?: number;
+    };
+    try {
+      const body = new URLSearchParams({
+        id_token: idToken,
+        client_id: channelId,
+      });
+      const verifyResponse = await fetch(LINE_VERIFY_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+        signal: controller.signal,
+      });
+      if (!verifyResponse.ok) {
+        console.warn(`LINE ID token verify failed: HTTP ${verifyResponse.status}`);
+        return res.status(401).json({ error: "Invalid ID token" });
+      }
+      verifyData = (await verifyResponse.json()) as typeof verifyData;
+    } catch (fetchError) {
+      if (fetchError instanceof Error && fetchError.name === "AbortError") {
+        console.warn("LINE ID token verify timed out (5s)");
+      } else {
+        console.warn("LINE ID token verify request error");
+      }
+      return res.status(401).json({ error: "Invalid ID token" });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    // クレーム検証: aud=channelId / iss=LINE / exp 未経過 / sub 必須
+    const nowSec = Math.floor(Date.now() / 1000);
+    const audOk = Array.isArray(verifyData.aud)
+      ? verifyData.aud.includes(channelId)
+      : verifyData.aud === channelId;
+    if (
+      !audOk ||
+      verifyData.iss !== "https://access.line.me" ||
+      typeof verifyData.exp !== "number" ||
+      verifyData.exp < nowSec ||
+      !verifyData.sub
+    ) {
+      console.warn("LINE ID token claim validation failed");
+      return res.status(401).json({ error: "Invalid ID token" });
+    }
+
+    const sub = verifyData.sub;
+    const appUid = await getOrCreateAppUidForLineId(sub);
+    if (!appUid) {
+      console.error("Failed to resolve appUid for verified LINE user");
+      return res.status(500).json({ error: "Failed to resolve user" });
+    }
+
+    // uid=appUid, custom claim lineId=検証済み LINE userId でトークン発行
+    const customToken = await getAuth().createCustomToken(appUid, { lineId: sub });
+    return res.status(200).json({ customToken });
+  } catch (error) {
+    // 生トークンを含めないよう message のみログ
+    console.error("Auth /line error:", (error as Error).message);
+    return res.status(401).json({ error: "Authentication failed" });
+  }
+});
+
 // Gmail API 専用の Express app を作成
 const gmailApp = express();
 gmailApp.use(express.json());
 gmailApp.use("/gmail", gmailRouter);
+gmailApp.use("/auth", authRouter);
 
 // Gmail API を Firebase Functions としてエクスポート（LINE webhook とは分離）
 // LINE通知を送信するためLINE認証情報、カテゴリ分類のためGEMINI_API_KEYも必要
+// LINE_LIFF_CHANNEL_ID は /auth/line の ID トークン検証に使用
 export const api = onRequest(
   {
     region: "us-central1",
-    secrets: ["ADMIN_SECRET", "GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "LINE_CHANNEL_TOKEN", "LINE_CHANNEL_SECRET", "GEMINI_API_KEY"],
+    secrets: ["ADMIN_SECRET", "GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "LINE_CHANNEL_TOKEN", "LINE_CHANNEL_SECRET", "GEMINI_API_KEY", "LINE_LIFF_CHANNEL_ID"],
   },
   gmailApp
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,6 +2075,837 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@liff/activity": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/activity/-/activity-2.30.0.tgz",
+      "integrity": "sha512-3lShbTQpUgvMQCZwMmrRR6+Eq9gAMwT1bcT7PF204xwOtOVkqxk0PgzOVkXi2wSaTvBg4KnW7YnNPFAajNaFGA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/native-bridge": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/add-to-home-screen": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/add-to-home-screen/-/add-to-home-screen-2.30.0.tgz",
+      "integrity": "sha512-OlmCn5DNg7o+KMqJ58WMsPSy2+hzUVdLDAdFnk00x3zWbz2S4Tli4IOGbmAYxzQGqYZPKLolK7QA6MPFURBcCg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/open-window": "2.30.0",
+        "@liff/types": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/analytics": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/analytics/-/analytics-2.30.0.tgz",
+      "integrity": "sha512-4Uo9I7Uhh+C76kr7uIHxXfS3FMdSrTXHUess8/AoOXXulkrzHEGUZ7arRWnLesA5AuitrtJq7+EQsBmd7kx63g==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/core": "2.30.0",
+        "@liff/get-profile": "2.30.0",
+        "@liff/get-version": "2.30.0",
+        "@liff/is-logged-in": "2.30.0",
+        "@liff/logger": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/types": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/calendar": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/calendar/-/calendar-2.30.0.tgz",
+      "integrity": "sha512-wkOx335FIhEynBBj+siyW86SvSE9JuxBg9Cq0P9zxvxtaBokmcGJdtZ57JiW/UrorTP/1/pnJeM08I0I4GAzCw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/native-bridge": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/check-availability": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/check-availability/-/check-availability-2.30.0.tgz",
+      "integrity": "sha512-6UanhyuhYxMNlXyId05eWtDs/qTjWItdbQhEIuK4SM0OZ91fh8g7zE1GBBE+p6na9So7vUKFmRP1OqtP9vEGRA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/get-version": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/types": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/close-window": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/close-window/-/close-window-2.30.0.tgz",
+      "integrity": "sha512-BFOvxpOoaYdGnS/DPDwf3ZwS2u0LeZGC7DyIVbTls4zEU7rkwBZ9m0K26zYjaWaxzC/BUqKoHjC98fL+ctgQeA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/get-line-version": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/native-bridge": "2.30.0",
+        "@liff/types": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/consts": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/consts/-/consts-2.30.0.tgz",
+      "integrity": "sha512-mb/spPw6MrI0OpcU/gM5a2Hc2jD0iJIgTHtGrsnROKz7eUKD3qg+ETerzsBHCNjn4PsWFiAM/kgP/W0BYFAHrw==",
+      "license": "SEE LICENSE IN README.md",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/core": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/core/-/core-2.30.0.tgz",
+      "integrity": "sha512-MGXpX5vWKzS+rU4iE+i5XrLJFda2ZM9yyXEWwIzpW9flvijbb3xKMChRwfxLDgp+V21+fYLKEs2ymtpYiOlQLg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/get-version": "2.30.0",
+        "@liff/init": "2.30.0",
+        "@liff/native-bridge": "2.30.0",
+        "@liff/ready": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/use": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/create-shortcut-on-home-screen": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/create-shortcut-on-home-screen/-/create-shortcut-on-home-screen-2.30.0.tgz",
+      "integrity": "sha512-wME3YNRMVlY5hJsPTs8O7EaY3W04h4rnnsUKKtSSIfWgosfpVTkzqWeSq6+mnoy+8TiysGvqfASRyWw+nRD7FQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/open-window": "2.30.0",
+        "@liff/permanent-link": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/extensions": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/extensions/-/extensions-2.30.0.tgz",
+      "integrity": "sha512-i3DOLyHho1VXj31XQmPwwZkxGLn7jNg8cJwVmV8WFLtYtzw2+vX/ksSkTMiGUTvrjG1NUzI3NHSZJp8GKSHJ4A==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/add-to-home-screen": "2.30.0",
+        "@liff/check-availability": "2.30.0",
+        "@liff/consts": "2.30.0",
+        "@liff/get-advertising-id": "2.30.0",
+        "@liff/get-line-version": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/logger": "2.30.0",
+        "@liff/scan-code": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/types": "2.30.0",
+        "@liff/util": "2.30.0"
+      }
+    },
+    "node_modules/@liff/get-advertising-id": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-advertising-id/-/get-advertising-id-2.30.0.tgz",
+      "integrity": "sha512-vmWdbniu64VjPOeNIV+/anU070rOO59Zy2VltPOuaqBm1aSbDvCatNwZVGG8HFkz5z643t5e9T8flTgAK6TcMA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/types": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-app-language": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-app-language/-/get-app-language-2.30.0.tgz",
+      "integrity": "sha512-7FjJNBcyVDynDzNo728UBw+ye1z0AeEYOkh6BAgel8BEAeinm84wCPuOCNEUw1k2jAU0MQT8CiVnBwft42dpKQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/get-line-version": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-friendship": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-friendship/-/get-friendship-2.30.0.tgz",
+      "integrity": "sha512-IUXwIwDPk7G+qer/f2/AXaxRR0W88N24FOZdxI6zC8wJhrapAqvQtfUv4grRtJopEr+Lh1ZdOnTkHok3e825Mg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/permission": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-language": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-language/-/get-language-2.30.0.tgz",
+      "integrity": "sha512-9Pg0zztWXf6v+2DcsHAFw7SxLZCGamzWfUJdFy7uBopHBE3sjuHNAiJmIAuR7EG45xUv5/xHa3vXuFY2LQmVpQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-line-version": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-line-version/-/get-line-version-2.30.0.tgz",
+      "integrity": "sha512-dUKYwlCFPtKqp5ikClzSvoEBHgmhhP+/WCkbjT955krmAd4bceGM7+K7jfa/n363J9aPgrWDFMrlm2GvfyDBnQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-origins": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-origins/-/get-origins-2.30.0.tgz",
+      "integrity": "sha512-ooNHrZQgix6crCSsxhosj+LFmnXWW67YkiN372vM2K+atT83FU5/ggVSaTxGw6AJzODX5g9SMj4rRrvuOS98AA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-os": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-os/-/get-os-2.30.0.tgz",
+      "integrity": "sha512-RQ9thtIt/R+jDenWWN7CL5R+Ej/g/zwHexpzeb0u8IYGWTpxCkk1w+fkm849CByQ96v1PzQeZCxAstVoZnmlaA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-profile": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-profile/-/get-profile-2.30.0.tgz",
+      "integrity": "sha512-glAKP0ADruyMqMmKBYePeqyc8PwTh3PPAaPLPj49+cWCcDWpBZs0M4lS98HCnalzrVyhN1ddt04j4BlX7Twm3w==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/permission": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/use": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-version": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-version/-/get-version-2.30.0.tgz",
+      "integrity": "sha512-1U90SfnIEWGZVgV/T6GggLlgVK0XrsXPJx7fO7McuqhRf60MMY9Hy249exfiME96ndSxxu1ne179FeSECziMmg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/hooks": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/hooks/-/hooks-2.30.0.tgz",
+      "integrity": "sha512-ZkiSOxu3v2mRLUaxyE4hxfrofk/xGmCAm+nxrIw5Ot9luhyBI3IYEX6gTa/BeqjdqsbfcFz8TwdFNuHP3zwByA==",
+      "license": "SEE LICENSE IN README.md",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/i18n": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/i18n/-/i18n-2.30.0.tgz",
+      "integrity": "sha512-hPxojgnTI0mNmELXc09kXrY/VJnkZzI8+9o/c6XgDUXNHdsEYJ7ld2uX4x0+qqQtGVcn4Mq4k+4JzPNW5j8KPw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/logger": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/iap": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/iap/-/iap-2.30.0.tgz",
+      "integrity": "sha512-xPs1hiFk1WmQXnHB1FCKa5YaFaK9k6A8oIvB00D7u35e7D7M9TQxlBriALCesEdjMR4mghc3FAPW6iin7LVyeA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/native-bridge": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/init": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/init/-/init-2.30.0.tgz",
+      "integrity": "sha512-49irD/0GWelmeXBKgbaMsRZb07qsdhS8GPX9dmZFaHB2pCNOm3aSv6OYNVM87tsdYLI1pXawAHezYj7V9zvzmg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/check-availability": "2.30.0",
+        "@liff/close-window": "2.30.0",
+        "@liff/consts": "2.30.0",
+        "@liff/extensions": "2.30.0",
+        "@liff/get-line-version": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/hooks": "2.30.0",
+        "@liff/i18n": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/is-logged-in": "2.30.0",
+        "@liff/is-sub-window": "2.30.0",
+        "@liff/logger": "2.30.0",
+        "@liff/login": "2.30.0",
+        "@liff/logout": "2.30.0",
+        "@liff/message-bus": "2.30.0",
+        "@liff/native-bridge": "2.30.0",
+        "@liff/permanent-link": "2.30.0",
+        "@liff/ready": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/sub-window": "2.30.0",
+        "@liff/types": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0",
+        "@liff/verify-id-token": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-api-available": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/is-api-available/-/is-api-available-2.30.0.tgz",
+      "integrity": "sha512-zXBSPIuOI40DNV8oGWP1g47IY+VwU2LJEUtHEkHUoEzp1CENrwdOrEeAAKTpa3p1DUAZqf+lZEEkEJTEcfD86Q==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/get-line-version": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/is-logged-in": "2.30.0",
+        "@liff/is-sub-window": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-in-client": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/is-in-client/-/is-in-client-2.30.0.tgz",
+      "integrity": "sha512-/dDitiORUK9ZuUMCs8VL8i3sOlfbzSbUDzsOOXw5sHj5XnJ45mnRCLHE9dFjdLAdA/fGi6Vn/drhkLm/iRB6lw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-logged-in": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/is-logged-in/-/is-logged-in-2.30.0.tgz",
+      "integrity": "sha512-226fXD2XgEGbVCNu8X+vQX9mJWWhPArR+oZq+xM4B0IpmxUYe+tY5Mj/2jlpjXnmD/oqqcG1d9PsWYmDuBkwcg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/store": "2.30.0",
+        "@liff/use": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-sub-window": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/is-sub-window/-/is-sub-window-2.30.0.tgz",
+      "integrity": "sha512-LodgPmjxBFFuzS0GjBrZ9zF6QIHUCUpDDfVSIqLBaqcqjzr2FzPnfWiklltiYZQ+Raa6QaQ99c+RYF30lwqUCg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/liff-types": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/liff-types/-/liff-types-2.30.0.tgz",
+      "integrity": "sha512-np55EqG0wla0NDLL56xEIE54mHe24pSbCUI8vXzb39xi1uGfr2e9yzpUjJ3M0J2irqz/NPPoeOQXPx93nheJCw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/activity": "2.30.0",
+        "@liff/analytics": "2.30.0",
+        "@liff/calendar": "2.30.0",
+        "@liff/close-window": "2.30.0",
+        "@liff/create-shortcut-on-home-screen": "2.30.0",
+        "@liff/get-app-language": "2.30.0",
+        "@liff/get-friendship": "2.30.0",
+        "@liff/get-language": "2.30.0",
+        "@liff/get-line-version": "2.30.0",
+        "@liff/get-origins": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/get-profile": "2.30.0",
+        "@liff/get-version": "2.30.0",
+        "@liff/i18n": "2.30.0",
+        "@liff/iap": "2.30.0",
+        "@liff/init": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/is-logged-in": "2.30.0",
+        "@liff/is-sub-window": "2.30.0",
+        "@liff/login": "2.30.0",
+        "@liff/logout": "2.30.0",
+        "@liff/native-bridge": "2.30.0",
+        "@liff/open-window": "2.30.0",
+        "@liff/permanent-link": "2.30.0",
+        "@liff/permission": "2.30.0",
+        "@liff/ready": "2.30.0",
+        "@liff/request-friendship": "2.30.0",
+        "@liff/scan-code-v2": "2.30.0",
+        "@liff/send-messages": "2.30.0",
+        "@liff/share-target-picker": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/sub-window": "2.30.0",
+        "@liff/use": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/logger": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/logger/-/logger-2.30.0.tgz",
+      "integrity": "sha512-rmjtmVAj613Yr/OxONK4bF696sQdvl5/pGiBBb8f5/I7T3u2sQu9vgpW7NO1CCbcUd9e5IRCnkiDZqI2PFT2pg==",
+      "license": "SEE LICENSE IN README.md",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/login": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/login/-/login-2.30.0.tgz",
+      "integrity": "sha512-1cebIYKt8CPHh77J2GdLcg/Phn8oCDZJQp5A0IFgtYmTZ5ZYEmS9toaBLQ2EEYLWkTcy3LlqasRpTMuXQo894g==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/get-version": "2.30.0",
+        "@liff/hooks": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/is-sub-window": "2.30.0",
+        "@liff/logger": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/sub-window": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0",
+        "tiny-sha256": "^1.0.2"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/logout": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/logout/-/logout-2.30.0.tgz",
+      "integrity": "sha512-Yv7mSYdnEWuFAQGe4uoAfZ4ogj02PmfR6c9ax3fHQwo8u/7MgU/Q4Fg4Qt49on4axql5wfsNZ7dLfY308TKLBg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/store": "2.30.0",
+        "@liff/use": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/message-bus": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/message-bus/-/message-bus-2.30.0.tgz",
+      "integrity": "sha512-hDo2HAqG8WN8/uDrNPTmWu2fJao1BJQKy5LgO0O7LDlV/Y3oLO9JpYmiGFoyhALVndH7aPopS18K1e5/iHdeAg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/native-bridge": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/native-bridge/-/native-bridge-2.30.0.tgz",
+      "integrity": "sha512-UCl+/5gLFp8wy2AYePA63MKjp3eQUPobFKRN9YWMo6B2TrAfhR6qtIl1N2eCpka1BXc1fhuRFe5y4YaMfZU+nQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/logger": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/types": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/open-window": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/open-window/-/open-window-2.30.0.tgz",
+      "integrity": "sha512-Mn+L+Cw2InzvdRD0c2ji/lEfmR/Wa4bi25m5GNHtfsViMhPnJ0gAUvlUhHokvqUVLwRd3uCvUkZk8beM46vusQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/get-line-version": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/native-bridge": "2.30.0",
+        "@liff/types": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/permanent-link": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/permanent-link/-/permanent-link-2.30.0.tgz",
+      "integrity": "sha512-+5Mdssjigu0N5alK701Eie8pKRFI9M65g16ntvxLVlFgSvOqrh0UTdj80s+OmMZAMmX1H26qUjGq3ag+GryBIg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/permission": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/permission/-/permission-2.30.0.tgz",
+      "integrity": "sha512-6jxKXlg+VWppfvE/qs/fWn1cja2CIMZDLQ8NFeLH8eZUW2EK/qEXe2hrnY2SwvEYbxLb2nvpksaFJ74HgDMz5g==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/sub-window": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0",
+        "@liff/verify-id-token": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/ready": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/ready/-/ready-2.30.0.tgz",
+      "integrity": "sha512-oDhMmPc0Q50ai1W40mRJNLtrxG/hO8Gv7J1uG+F1hoKN/YLarXRb3do5bCR93bBZ5t9bDaB/Qn37V1JPved5Gw==",
+      "license": "SEE LICENSE IN README.md",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/request-friendship": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/request-friendship/-/request-friendship-2.30.0.tgz",
+      "integrity": "sha512-ch8vTR0WENZl+1NCZ7ftqvnAFEMhzG3PPbc3lrvNBu4F1KlD65D3jZ0YlIrMJnGtcD3nSFAikCfAI9JgqFG1eQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/sub-window": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/scan-code": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code/-/scan-code-2.30.0.tgz",
+      "integrity": "sha512-o/da0ePpjYojCWzczzthD59vJx3RCGMmnNX7/eITSDWjxhVDbVSw16nDGFMG5yzy64Zc+NF5/Nm22MW9sGm/dA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/types": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/scan-code-v2": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code-v2/-/scan-code-v2-2.30.0.tgz",
+      "integrity": "sha512-XN14FpsnzQUdxkZ5h7afoIUDtGBGuXwEV7vYynPTLNMLDi9aWFH7ptoTk/X1uhbDgqQU4YRnvh+azMnXGK8Msg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/sub-window": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/send-messages": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/send-messages/-/send-messages-2.30.0.tgz",
+      "integrity": "sha512-VHHyykl01F7mepRswhi1oIGIkZNpqUG8AaRMmS670WIX+CGKNwk2o5LrLLqolxZ9t5xXFVzO7gWm4YVIXtwP9w==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/get-line-version": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/permission": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0",
+        "@line/bot-sdk": "^10.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/send-messages/node_modules/@line/bot-sdk": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-10.8.0.tgz",
+      "integrity": "sha512-1Mdpw/WPS3QP6fGiwPRTL27k8MgmMe7rVKCKsItP/kPzogX7a/X1ipQqk/F6RkorP9DNyJIx590hnVUkfBQf3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^24.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "axios": "^1.7.4"
+      }
+    },
+    "node_modules/@liff/server-api": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/server-api/-/server-api-2.30.0.tgz",
+      "integrity": "sha512-mCFNe9qQ84kGREXArQRMGVoQT6MDEG4ILjRb1Efkqla5nXhQVDQSXHhBXjZ8fS1nYCZ9KDYWaaDstriLQdi7QA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/share-target-picker": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/share-target-picker/-/share-target-picker-2.30.0.tgz",
+      "integrity": "sha512-kzzSI0nSP89bmVxpYQF3gSA80sTJBPtDn7OHFAvxo4gXbMsQpWnh12D+zG1WqKB+tR7QYHM/HLy+u9LTc3AxKA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/analytics": "2.30.0",
+        "@liff/consts": "2.30.0",
+        "@liff/get-line-version": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/is-logged-in": "2.30.0",
+        "@liff/is-sub-window": "2.30.0",
+        "@liff/logger": "2.30.0",
+        "@liff/send-messages": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/types": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0",
+        "@liff/window-postmessage": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/store": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/store/-/store-2.30.0.tgz",
+      "integrity": "sha512-lSCHpDckEIMWE6l0Wi80YTL+Hh2gwjUp9aPRbYPxLiS9Sf80BEDyKrpUEfV1QSyZeWLOyIW60RBy5nSsMGzZ7g==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/types": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/sub-window": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/sub-window/-/sub-window-2.30.0.tgz",
+      "integrity": "sha512-CRr2/fRYRLMa/umylFDAoGuDzaa+tBWAFyjFVhxMRxO2fj+Mst0SADjhjCdUQAZ9PbunRXd2RXWRiqRDp/RRqg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/close-window": "2.30.0",
+        "@liff/consts": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/is-sub-window": "2.30.0",
+        "@liff/logger": "2.30.0",
+        "@liff/message-bus": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/types": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/types/-/types-2.30.0.tgz",
+      "integrity": "sha512-39p+c3HcbRkHlSklPgj/0jgCPfqXxRdZo1d6kY4X74kTKhjyQ2nIMmFPiByt70ZuGSZoVcYoHpeaCl/hsPIgdQ==",
+      "license": "SEE LICENSE IN README.md"
+    },
+    "node_modules/@liff/use": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/use/-/use-2.30.0.tgz",
+      "integrity": "sha512-WBFpLcEmE6WmhNmUpSDLFCbiaZFnIsbVDuFQk7KKljss8wP4XAFiKt8hKUaSUWZcF5QZpUAssq4JDunMmradKw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/hooks": "2.30.0",
+        "@liff/logger": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/util": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/util/-/util-2.30.0.tgz",
+      "integrity": "sha512-z0cC94MBDxuFAz+J4ybGx5PJLEqUzmpcYGt+Mk0mAhTvdJIBWpcyx2/VGZYDKTdXOKS9vz1u+iM3A0zGBk4lBg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/logger": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/verify-id-token": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/verify-id-token/-/verify-id-token-2.30.0.tgz",
+      "integrity": "sha512-lUFwxRVMUhi79FyMO7bprKJRFgfNUxOlVbOds3N+DaVPctu8qpAraNI7YlteQuqBoeVXGu4uZ4I+MCJi7zA7gA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/window-postmessage": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@liff/window-postmessage/-/window-postmessage-2.30.0.tgz",
+      "integrity": "sha512-tOjy8WX7+sUo1NtGcaaNzSCvSzYI51zESTIDK9GN9lHSYvOBi420kFPhfiZ9DexOTcIndCg3Vw7WYRO18x0DSQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.30.0",
+        "@liff/logger": "2.30.0",
+        "@liff/util": "2.30.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
     "node_modules/@line/bot-sdk": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-11.1.0.tgz",
@@ -2085,6 +2916,57 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@line/liff": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@line/liff/-/liff-2.30.0.tgz",
+      "integrity": "sha512-vxC6x7bRaM8E0fU3erdATbxsT/v066kJ9ck466aWYyQlkAw43oni6jUI+lToJgBrw9iQw8sVtou+MiRdqNiRiA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/activity": "2.30.0",
+        "@liff/analytics": "2.30.0",
+        "@liff/calendar": "2.30.0",
+        "@liff/close-window": "2.30.0",
+        "@liff/consts": "2.30.0",
+        "@liff/core": "2.30.0",
+        "@liff/create-shortcut-on-home-screen": "2.30.0",
+        "@liff/extensions": "2.30.0",
+        "@liff/get-app-language": "2.30.0",
+        "@liff/get-friendship": "2.30.0",
+        "@liff/get-language": "2.30.0",
+        "@liff/get-line-version": "2.30.0",
+        "@liff/get-origins": "2.30.0",
+        "@liff/get-os": "2.30.0",
+        "@liff/get-profile": "2.30.0",
+        "@liff/get-version": "2.30.0",
+        "@liff/hooks": "2.30.0",
+        "@liff/i18n": "2.30.0",
+        "@liff/iap": "2.30.0",
+        "@liff/init": "2.30.0",
+        "@liff/is-api-available": "2.30.0",
+        "@liff/is-in-client": "2.30.0",
+        "@liff/is-logged-in": "2.30.0",
+        "@liff/is-sub-window": "2.30.0",
+        "@liff/liff-types": "2.30.0",
+        "@liff/login": "2.30.0",
+        "@liff/logout": "2.30.0",
+        "@liff/native-bridge": "2.30.0",
+        "@liff/open-window": "2.30.0",
+        "@liff/permanent-link": "2.30.0",
+        "@liff/permission": "2.30.0",
+        "@liff/ready": "2.30.0",
+        "@liff/request-friendship": "2.30.0",
+        "@liff/scan-code-v2": "2.30.0",
+        "@liff/send-messages": "2.30.0",
+        "@liff/server-api": "2.30.0",
+        "@liff/share-target-picker": "2.30.0",
+        "@liff/store": "2.30.0",
+        "@liff/sub-window": "2.30.0",
+        "@liff/use": "2.30.0",
+        "@liff/util": "2.30.0",
+        "tslib": "^2.3.0",
+        "whatwg-fetch": "^3.0.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -11406,6 +12288,12 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tiny-sha256": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-sha256/-/tiny-sha256-1.0.2.tgz",
+      "integrity": "sha512-IdsPtu8eJ0SwuCWUFm2euFH3jJvtpGQC0VpZNZlqxRvQ2zGvSjbXDO+4T8Rm5ETsmCQHHvKUGds69bJYrlb3Tg==",
+      "license": "Public domain"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -12089,6 +12977,12 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -12374,6 +13268,7 @@
     "web": {
       "version": "0.1.0",
       "dependencies": {
+        "@line/liff": "^2.30.0",
         "dayjs": "^1.11.21",
         "firebase": "^12.15.0",
         "firebase-admin": "^14.1.0",

--- a/web/.env.example
+++ b/web/.env.example
@@ -23,3 +23,15 @@ NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id-here
 
 # Firebase Measurement ID (for Google Analytics)
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=G-PLNC7GY160
+
+# LINE Login (LIFF) — required for real authentication in production.
+# LIFF app id from the LINE Developers console (LINE Login channel > LIFF).
+# If UNSET (local dev / preview without a LIFF app), the web falls back to
+# Firebase anonymous sign-in, which carries NO lineId claim and (under the
+# locked Firestore rules) can read no data — a fail-safe, never URL-based identity.
+NEXT_PUBLIC_LIFF_ID=your-liff-id-here
+
+# Auth endpoint that mints a Firebase custom token from a verified LIFF ID token.
+# This is the bot `api` function base URL + /auth/line, e.g.
+# https://us-central1-line-kakeibo-0410.cloudfunctions.net/api/auth/line
+NEXT_PUBLIC_AUTH_ENDPOINT=https://us-central1-line-kakeibo-0410.cloudfunctions.net/api/auth/line

--- a/web/app/expenses/page.tsx
+++ b/web/app/expenses/page.tsx
@@ -53,7 +53,7 @@ function ExpensesPageLoading() {
 }
 
 function ExpensesPageContent() {
-  const { user, loading: authLoading } = useLineAuth();
+  const { lineId, loading: authLoading } = useLineAuth();
   const [dateSettings, setDateSettings] = useState<DateRangeSettings>(DEFAULT_SETTINGS);
   const [currentMonth, setCurrentMonth] = useState(dayjs());
   // Initialize dateRange synchronously to avoid undefined→value transition causing double fetch
@@ -69,15 +69,16 @@ function ExpensesPageContent() {
   const [editMonthSet, setEditMonthSet] = useState(false);
 
   // URLからパラメータを取得（useSearchParamsでハイドレーション安全に取得）
+  // edit / expenseId はドキュメントIDであり、認証（本人特定）には使わない。
+  // 本人特定は検証済みクレームの lineId のみで行う（URL の lineId は信用しない）。
   const searchParams = useSearchParams();
-  const lineIdFromUrl = searchParams.get('lineId');
   const editExpenseId = searchParams.get('edit');
 
-  // LINE IDがある場合は直接それを使用、なければuser.uidを使用
-  const effectiveUserId = lineIdFromUrl || user?.uid || null;
+  // データ取得は検証済み lineId クレームでのみ行う
+  const effectiveUserId = lineId;
 
-  // ゲスト（プレビュー）モード判定: lineIdなしで開かれた場合
-  const isGuest = !lineIdFromUrl && (user?.uid === 'guest' || user?.isAnonymous === true);
+  // ゲスト（プレビュー）モード判定: 検証済み lineId がない場合
+  const isGuest = !lineId;
 
   // Load date settings from Firestore on mount
   useEffect(() => {
@@ -1235,7 +1236,7 @@ function ExpensesPageContent() {
               </div>
               <div className="flex gap-2 border-t border-line/60 p-3">
                 <a
-                  href={`/attach?expenseId=${encodeURIComponent(receiptPreview.expenseId)}${lineIdFromUrl ? `&lineId=${encodeURIComponent(lineIdFromUrl)}` : ""}`}
+                  href={`/attach?expenseId=${encodeURIComponent(receiptPreview.expenseId)}`}
                   className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-accent/12 px-4 py-2.5 text-sm font-medium text-accent transition-colors hover:bg-accent/20"
                 >
                   <RefreshCw className="h-4 w-4" />

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -252,8 +252,8 @@ function BudgetProgress({ stats, budgetConfig }: { stats: ExpenseStats | null; b
 
 /* ------------------------------- Page ----------------------------------- */
 export default function Dashboard() {
-  const { user, loading: authLoading } = useLineAuth();
-  const dsCacheKey = user?.uid ? `dateSettings:${user.uid}` : '';
+  const { lineId, loading: authLoading } = useLineAuth();
+  const dsCacheKey = lineId ? `dateSettings:${lineId}` : '';
   const [currentDate, setCurrentDate] = useState(dayjs());
   const [dateSettings, setDateSettings] = useState<DateRangeSettings>(
     () => (dsCacheKey && getCached<DateRangeSettings>(dsCacheKey)) || { mode: 'monthly' }
@@ -263,7 +263,7 @@ export default function Dashboard() {
   const [firebaseError, setFirebaseError] = useState(false);
 
   const { config: budgetConfig, loading: budgetLoading, error: budgetError, refetch: refetchBudget } =
-    useBudgetConfig(user?.uid || null);
+    useBudgetConfig(lineId);
 
   const sampleStats = useMemo(() => getSampleStats(), []);
 
@@ -273,11 +273,11 @@ export default function Dashboard() {
 
   useEffect(() => {
     const load = async () => {
-      if (!user?.uid) {
+      if (!lineId) {
         setSettingsLoading(false);
         return;
       }
-      const key = `dateSettings:${user.uid}`;
+      const key = `dateSettings:${lineId}`;
       const cached = getCached<DateRangeSettings>(key);
       // キャッシュがあれば即表示して裏で再取得（スピナーを出さない）
       if (cached) {
@@ -287,7 +287,7 @@ export default function Dashboard() {
         setSettingsLoading(true);
       }
       try {
-        const fresh = await getDateRangeSettings(user.uid);
+        const fresh = await getDateRangeSettings(lineId);
         setCached(key, fresh);
         setDateSettings(fresh);
       } catch (e) {
@@ -298,11 +298,11 @@ export default function Dashboard() {
       }
     };
     load();
-  }, [user?.uid]);
+  }, [lineId]);
 
   const effectiveRange = getEffectiveDateRange(currentDate, dateSettings);
   const { stats, loading: statsLoading } = useMonthlyStats(
-    user?.uid || null,
+    lineId,
     currentDate.year(),
     currentDate.month() + 1,
     dateSettings.customStartDay || 1,
@@ -314,7 +314,7 @@ export default function Dashboard() {
   const prevDate = currentDate.subtract(1, 'month');
   const prevRange = getEffectiveDateRange(prevDate, dateSettings);
   const { stats: prevStats } = useMonthlyStats(
-    user?.uid || null,
+    lineId,
     prevDate.year(),
     prevDate.month() + 1,
     dateSettings.customStartDay || 1,
@@ -352,7 +352,7 @@ export default function Dashboard() {
     );
   }
 
-  const isGuest = user?.uid === 'guest' || user?.isAnonymous === true;
+  const isGuest = !lineId;
   const displayStats = isGuest ? sampleStats : stats;
 
   const totalExpense = displayStats?.totalAmount || 0;

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -7,7 +7,6 @@ import { useLineAuth } from '../../lib/hooks';
 import { getDateRangeSettings, saveDateRangeSettings, migrateLocalToFirestore, DEFAULT_SETTINGS, type DateRangeSettings } from '../../lib/dateSettings';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
-import PreviewModeBanner from '../../components/PreviewModeBanner';
 import { getCategoryVisual } from '../../lib/categoryVisuals';
 import { CANONICAL_CATEGORIES } from '../../lib/categoryNormalization';
 import { getCached, setCached } from '../../lib/swrCache';
@@ -55,11 +54,11 @@ function normalizeBudgetConfig(data: unknown): BudgetConfig {
 }
 
 export default function Settings() {
-  const { user, loading: authLoading, getUrlWithLineId } = useLineAuth();
+  const { lineId, loading: authLoading, getUrlWithLineId } = useLineAuth();
 
   // 再訪時の全画面スピナーを避けるためのキャッシュキー
-  const dsCacheKey = user?.uid ? `dateSettings:${user.uid}` : '';
-  const sbCacheKey = user?.uid ? `settingsBudget:${user.uid}` : '';
+  const dsCacheKey = lineId ? `dateSettings:${lineId}` : '';
+  const sbCacheKey = lineId ? `settingsBudget:${lineId}` : '';
   const cachedDate = dsCacheKey ? getCached<DateRangeSettings>(dsCacheKey) : undefined;
   const cachedBudget = sbCacheKey ? getCached<BudgetConfig>(sbCacheKey) : undefined;
 
@@ -82,20 +81,20 @@ export default function Settings() {
 
   useEffect(() => {
     const loadAllSettings = async () => {
-      if (!user?.uid) {
+      if (!lineId) {
         setLoading(false);
         return;
       }
 
       // キャッシュがあれば即表示し、裏で再取得（スピナーを出さない）
-      const hadCache = !!(getCached(`dateSettings:${user.uid}`) && getCached(`settingsBudget:${user.uid}`));
+      const hadCache = !!(getCached(`dateSettings:${lineId}`) && getCached(`settingsBudget:${lineId}`));
       try {
         if (!hadCache) setLoading(true);
 
         // 期間設定の読み込み
-        await migrateLocalToFirestore(user.uid);
-        const loadedDateSettings = await getDateRangeSettings(user.uid);
-        setCached(`dateSettings:${user.uid}`, loadedDateSettings);
+        await migrateLocalToFirestore(lineId);
+        const loadedDateSettings = await getDateRangeSettings(lineId);
+        setCached(`dateSettings:${lineId}`, loadedDateSettings);
         setDateSettings(loadedDateSettings);
         setTempStartDate(loadedDateSettings.startDate || '');
         setTempEndDate(loadedDateSettings.endDate || '');
@@ -103,11 +102,11 @@ export default function Settings() {
 
         // 予算設定の読み込み
         if (db) {
-          const docRef = doc(db, 'budgetSettings', user.uid);
+          const docRef = doc(db, 'budgetSettings', lineId);
           const docSnap = await getDoc(docRef);
           if (docSnap.exists()) {
             const normalizedConfig = normalizeBudgetConfig(docSnap.data());
-            setCached(`settingsBudget:${user.uid}`, normalizedConfig);
+            setCached(`settingsBudget:${lineId}`, normalizedConfig);
             setBudgetConfig(normalizedConfig);
           }
           setBudgetHasLoaded(true);
@@ -122,10 +121,10 @@ export default function Settings() {
     };
 
     loadAllSettings();
-  }, [user?.uid]);
+  }, [lineId]);
 
   const saveDateSettingsHandler = async () => {
-    if (!user?.uid) return;
+    if (!lineId) return;
 
     const newSettings: DateRangeSettings = {
       mode: dateSettings.mode,
@@ -138,14 +137,14 @@ export default function Settings() {
       }),
     };
 
-    await saveDateRangeSettings(user.uid, newSettings);
+    await saveDateRangeSettings(lineId, newSettings);
     setDateSettings(newSettings);
     // 保存後はキャッシュも更新（ホーム/再訪時に最新を即表示）
-    setCached(`dateSettings:${user.uid}`, newSettings);
+    setCached(`dateSettings:${lineId}`, newSettings);
   };
 
   const saveBudgetSettingsHandler = async () => {
-    if (!user?.uid || !db) return;
+    if (!lineId || !db) return;
 
     if (budgetLoadError || !budgetHasLoaded) {
       setMessage({ type: 'error', text: '設定を正常に読み込めていないため、保存できません' });
@@ -157,18 +156,18 @@ export default function Settings() {
       return;
     }
 
-    const docRef = doc(db, 'budgetSettings', user.uid);
+    const docRef = doc(db, 'budgetSettings', lineId);
     await setDoc(docRef, {
       ...budgetConfig,
       updatedAt: new Date(),
     });
     // 保存後はキャッシュも更新（settings再訪・ホームの予算表示に即反映）
-    setCached(`settingsBudget:${user.uid}`, budgetConfig);
-    setCached(`budget:${user.uid}`, budgetConfig);
+    setCached(`settingsBudget:${lineId}`, budgetConfig);
+    setCached(`budget:${lineId}`, budgetConfig);
   };
 
   const handleSaveAll = async () => {
-    if (!user?.uid) {
+    if (!lineId) {
       setMessage({ type: 'error', text: 'ユーザー情報が取得できません' });
       return;
     }
@@ -201,12 +200,12 @@ export default function Settings() {
     );
   }
 
-  if (!user) {
+  if (!lineId) {
     return (
       <div className="mx-auto flex min-h-[60vh] max-w-md items-center px-4">
         <div className="glass w-full rounded-2xl p-8 text-center shadow-glass">
           <h1 className="text-lg font-semibold text-fg">ログインが必要です</h1>
-          <p className="mt-1.5 text-sm text-muted">設定を変更するにはログインしてください</p>
+          <p className="mt-1.5 text-sm text-muted">設定を変更するにはLINEログインが必要です</p>
           <a
             href={getUrlWithLineId('/')}
             className="mt-4 inline-flex items-center rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-fg transition-colors hover:opacity-90"
@@ -220,12 +219,6 @@ export default function Settings() {
 
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-5 md:px-8 md:py-7">
-      {(user.uid === 'guest' || user.isAnonymous) && (
-        <div className="mb-4">
-          <PreviewModeBanner />
-        </div>
-      )}
-
       <main>
         {/* Message */}
         {message && (

--- a/web/components/layout/AppShell.tsx
+++ b/web/components/layout/AppShell.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { Sidebar } from './Sidebar';
 import { BottomTabBar } from './BottomTabBar';
 import { TopBar } from './TopBar';
+import { initLineAuth } from '@/lib/lineAuth';
 
 // Routes that should render without the app navigation chrome
 // (single-purpose / standalone screens opened from outside the app).
@@ -14,16 +15,14 @@ const BARE_ROUTES = ['/attach', '/link', '/debug'];
 export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() || '/';
   const reduceMotion = useReducedMotion();
-  const [lineId, setLineId] = useState<string | null>(null);
 
-  // Read lineId after mount to keep SSR/first-render markup stable (no hydration mismatch).
+  // アプリ起動時に1度だけサインイン（LIFF または匿名フォールバック）を開始する。
+  // 認証は Firebase に永続化されるため、遷移ごとに URL へ lineId を引き回す必要はない。
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    setLineId(params.get('lineId'));
-  }, [pathname]);
+    initLineAuth();
+  }, []);
 
-  const hrefFor = (path: string) =>
-    lineId ? `${path}?lineId=${encodeURIComponent(lineId)}` : path;
+  const hrefFor = (path: string) => path;
 
   const bare = BARE_ROUTES.some((r) => pathname === r || pathname.startsWith(`${r}/`));
 

--- a/web/lib/hooks.ts
+++ b/web/lib/hooks.ts
@@ -13,7 +13,9 @@ import {
   deleteDoc,
   FirestoreError
 } from 'firebase/firestore';
-import { db, getFirebaseStatus, ensureFirebaseInitialized } from './firebase';
+import { onAuthStateChanged, signOut as firebaseSignOut } from 'firebase/auth';
+import { db, auth, getFirebaseStatus, ensureFirebaseInitialized } from './firebase';
+import { initLineAuth, getLineIdClaim } from './lineAuth';
 import dayjs from 'dayjs';
 import { normalizeCategoryName } from './categoryNormalization';
 import { getCached, setCached, hasCached } from './swrCache';
@@ -194,73 +196,80 @@ const waitForFirebase = async (maxWaitMs: number = 5000, signal?: AbortSignal): 
   return checkFirebaseConnection();
 };
 
-// 認証はURL(lineId)から同期的に導出でき、アプリ内ナビでは値が変わらない。
-// 解決結果をモジュールに保持し、ページ再マウント時はそこから即時復元することで、
-// タブ切替のたびに全画面スピナーが1フレーム出る「リロード感」をなくす。
-// 初回ロードは null/loading=true で始まる（SSRと一致しハイドレーション不整合を避ける）。
-let cachedLineAuth: { uid: string; isAnonymous: boolean } | null = null;
-
-function getLineIdFromUrl(): string | null {
-  if (typeof window === 'undefined') return null;
-  const urlParams = new URLSearchParams(window.location.search);
-  let lineId = urlParams.get('lineId');
-  if (!lineId && window.location.hash) {
-    const hashParams = new URLSearchParams(window.location.hash.replace('#', ''));
-    lineId = hashParams.get('lineId');
-  }
-  if (!lineId) {
-    const match = window.location.href.match(/[?&]lineId=([^&]+)/);
-    if (match) {
-      lineId = decodeURIComponent(match[1]);
-    }
-  }
-  return lineId;
+// 認証は Firebase の onAuthStateChanged + カスタムクレームで駆動する。
+// URL の lineId は一切信用しない（旧方式の脆弱性の除去）。
+// - uid      … appUid（auth.currentUser.uid）
+// - lineId   … 検証済み LINE userId（ID トークンの custom claim。匿名時は null）
+// - isAnonymous … 匿名フォールバック（＝lineId なし。データにアクセスできない）
+// 解決結果はモジュールに保持し、ページ再マウント時に即時復元してスピナーの点滅を防ぐ。
+interface LineAuthState {
+  uid: string;
+  lineId: string | null;
+  isAnonymous: boolean;
 }
 
+let cachedLineAuth: LineAuthState | null = null;
+
 export function useLineAuth() {
-  const [user, setUser] = useState<{ uid: string; isAnonymous: boolean } | null>(() => cachedLineAuth);
+  const [state, setState] = useState<LineAuthState | null>(() => cachedLineAuth);
   const [loading, setLoading] = useState(() => cachedLineAuth === null);
 
   useEffect(() => {
-    const lineId = getLineIdFromUrl();
+    ensureFirebaseInitialized();
+    // 起動時サインイン（LIFF もしくは匿名フォールバック）を確実に開始する
+    initLineAuth();
 
-    const resolved = lineId
-      ? { uid: lineId, isAnonymous: false }
-      : { uid: 'guest', isAnonymous: true };
+    if (!auth) {
+      setLoading(false);
+      return;
+    }
 
-    cachedLineAuth = resolved;
-    setUser(resolved);
-    setLoading(false);
+    const unsubscribe = onAuthStateChanged(auth, async (fbUser) => {
+      if (!fbUser) {
+        cachedLineAuth = null;
+        setState(null);
+        setLoading(false);
+        return;
+      }
+
+      // lineId は検証済みクレームからのみ取得（匿名ユーザーは null）
+      const lineId = await getLineIdClaim(fbUser);
+      const resolved: LineAuthState = {
+        uid: fbUser.uid,
+        lineId,
+        isAnonymous: fbUser.isAnonymous || !lineId,
+      };
+
+      cachedLineAuth = resolved;
+      setState(resolved);
+      setLoading(false);
+    });
+
+    return () => unsubscribe();
   }, []);
 
   const signOutUser = async () => {
-    // LINE IDベースの認証では、URLを変更してLINE IDを削除
-    const url = new URL(window.location.href);
-    url.searchParams.delete('lineId');
-    window.history.replaceState({}, '', url.toString());
-
-    // ゲストユーザーに戻す（モジュールキャッシュも同期）
-    cachedLineAuth = { uid: 'guest', isAnonymous: true };
-    setUser({ uid: 'guest', isAnonymous: true });
-  };
-
-  // URLパラメータを保持してページ遷移するためのヘルパー関数
-  const getUrlWithLineId = (path: string) => {
-    if (typeof window === 'undefined') return path;
-    const urlParams = new URLSearchParams(window.location.search);
-    const lineId = urlParams.get('lineId');
-    if (lineId) {
-      return `${path}?lineId=${encodeURIComponent(lineId)}`;
+    try {
+      if (auth) await firebaseSignOut(auth);
+    } catch (e) {
+      console.error('Sign out failed:', e);
     }
-    return path;
+    cachedLineAuth = null;
+    setState(null);
   };
 
-  return { 
-    user, 
-    loading, 
+  // 旧: URL に lineId を引き回すヘルパー。現在は認証が Firebase に永続化されるため
+  // URL への付与は不要。互換のため関数は残し、パスをそのまま返す。
+  const getUrlWithLineId = (path: string) => path;
+
+  return {
+    user: state ? { uid: state.uid, isAnonymous: state.isAnonymous } : null,
+    uid: state?.uid ?? null,
+    lineId: state?.lineId ?? null,
+    loading,
     signOut: signOutUser,
-    isAnonymous: user?.isAnonymous || true,
-    getUrlWithLineId
+    isAnonymous: state?.isAnonymous ?? true,
+    getUrlWithLineId,
   };
 }
 

--- a/web/lib/lineAuth.ts
+++ b/web/lib/lineAuth.ts
@@ -1,0 +1,122 @@
+'use client';
+
+import {
+  signInWithCustomToken,
+  signInAnonymously,
+  type User,
+} from 'firebase/auth';
+import { auth, ensureFirebaseInitialized } from './firebase';
+
+// initLineAuth() はアプリ起動時に1度だけ実行する。
+// 二重実行や再マウントでも初回の Promise を使い回す。
+let initPromise: Promise<void> | null = null;
+
+/**
+ * サインイン状態を確立する。
+ * - NEXT_PUBLIC_LIFF_ID あり: LIFF で LINE ログイン → ID トークンを
+ *   認証エンドポイント(POST)へ送り、返ってきたカスタムトークンで
+ *   Firebase にサインインする（uid=appUid, claim lineId=検証済み LINE userId）。
+ * - NEXT_PUBLIC_LIFF_ID なし（ローカル/プレビュー）: 匿名サインインへフォールバック。
+ *   匿名ユーザーは lineId クレームを持たないため、ロックされた Firestore ルール下では
+ *   一切のデータにアクセスできない（フェイルセーフ）。URL の lineId は決して信用しない。
+ */
+export function initLineAuth(): Promise<void> {
+  if (typeof window === 'undefined') return Promise.resolve();
+  if (initPromise) return initPromise;
+
+  initPromise = (async () => {
+    ensureFirebaseInitialized();
+    if (!auth) {
+      console.error('Firebase Auth is not initialized; cannot start LINE auth');
+      return;
+    }
+
+    // すでにサインイン済みなら何もしない（Firebase がセッションを永続化している）
+    if (auth.currentUser) return;
+
+    const liffId = process.env.NEXT_PUBLIC_LIFF_ID;
+
+    // LIFF 未設定: 匿名フォールバック（lineId クレームなし＝データは見えない）
+    if (!liffId) {
+      try {
+        await signInAnonymously(auth);
+      } catch (e) {
+        console.error('Anonymous sign-in failed:', e);
+      }
+      return;
+    }
+
+    try {
+      const liff = (await import('@line/liff')).default;
+      await liff.init({ liffId });
+
+      if (!liff.isLoggedIn()) {
+        // LINE ログイン画面へリダイレクト（この後の処理は戻ってきてから再実行される）
+        liff.login();
+        return;
+      }
+
+      const idToken = liff.getIDToken();
+      if (!idToken) {
+        console.error('LIFF ID token is missing; falling back to anonymous');
+        await signInAnonymously(auth);
+        return;
+      }
+
+      const endpoint = process.env.NEXT_PUBLIC_AUTH_ENDPOINT;
+      if (!endpoint) {
+        console.error(
+          'NEXT_PUBLIC_AUTH_ENDPOINT is not set; falling back to anonymous'
+        );
+        await signInAnonymously(auth);
+        return;
+      }
+
+      const resp = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ idToken }),
+      });
+
+      if (!resp.ok) {
+        console.error('Auth endpoint returned HTTP', resp.status);
+        await signInAnonymously(auth);
+        return;
+      }
+
+      const data = (await resp.json()) as { customToken?: string };
+      if (!data.customToken) {
+        console.error('No customToken in auth response; falling back to anonymous');
+        await signInAnonymously(auth);
+        return;
+      }
+
+      await signInWithCustomToken(auth, data.customToken);
+    } catch (e) {
+      console.error('LINE auth flow failed; falling back to anonymous:', e);
+      try {
+        await signInAnonymously(auth);
+      } catch (anonError) {
+        console.error('Anonymous fallback sign-in failed:', anonError);
+      }
+    }
+  })();
+
+  return initPromise;
+}
+
+/**
+ * 検証済み LINE userId を Firebase ID トークンのカスタムクレームから取り出す。
+ * 匿名ユーザーやクレーム未設定の場合は null。
+ */
+export async function getLineIdClaim(user: User | null): Promise<string | null> {
+  if (!user || user.isAnonymous) return null;
+  try {
+    const result = await user.getIdTokenResult();
+    const lineId = result.claims.lineId;
+    return typeof lineId === 'string' && lineId ? lineId : null;
+  } catch (e) {
+    console.error('Failed to read lineId claim:', e);
+    return null;
+  }
+}

--- a/web/lib/lineAuth.ts
+++ b/web/lib/lineAuth.ts
@@ -31,17 +31,26 @@ export function initLineAuth(): Promise<void> {
       return;
     }
 
-    // すでにサインイン済みなら何もしない（Firebase がセッションを永続化している）
-    if (auth.currentUser) return;
+    // 永続化されたセッションの復元完了を待ってから判定する
+    // （復元前は currentUser が null のため、待たないと二重サインインし得る）
+    await auth.authStateReady();
+
+    // LINE 認証済み（非匿名）セッションが復元されたなら何もしない。
+    // 匿名セッションは一時フォールバックの名残なのでスキップ対象にしない。
+    // （匿名で早期 return すると、一度の失敗で以後 LIFF を再試行できず
+    //   永久にゲスト化してしまう）
+    if (auth.currentUser && !auth.currentUser.isAnonymous) return;
 
     const liffId = process.env.NEXT_PUBLIC_LIFF_ID;
 
     // LIFF 未設定: 匿名フォールバック（lineId クレームなし＝データは見えない）
     if (!liffId) {
-      try {
-        await signInAnonymously(auth);
-      } catch (e) {
-        console.error('Anonymous sign-in failed:', e);
+      if (!auth.currentUser) {
+        try {
+          await signInAnonymously(auth);
+        } catch (e) {
+          console.error('Anonymous sign-in failed:', e);
+        }
       }
       return;
     }

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "deploy:all": "./deploy-all.sh"
   },
   "dependencies": {
+    "@line/liff": "^2.30.0",
     "dayjs": "^1.11.21",
     "firebase": "^12.15.0",
     "firebase-admin": "^14.1.0",
@@ -24,10 +25,10 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
+    "@tailwindcss/postcss": "^4.3.2",
     "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@tailwindcss/postcss": "^4.3.2",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.10",
     "postcss": "^8.5.16",


### PR DESCRIPTION
## 🔒 背景(修正する脆弱性)

現状、web は**認証が実質存在しません**。`web/lib/hooks.ts` の `useLineAuth()` が URL クエリの `lineId` を**検証ゼロ**で本人 ID として信用し、ブラウザから Firebase Web SDK で直接 Firestore を読むため、`https://line-kakeibo.vercel.app?lineId=<victim>` を開くだけで**他人の家計簿が閲覧可能**でした(さらに rules が全開放のため全ユーザーの読み書き削除も可能。※ rules 側は別PRで対応)。

本PRは URL 依存の identity を廃止し、**LINE ログイン(LIFF)→ 検証済み Firebase カスタムトークン**による本人認証に置き換えます。

## 📋 変更内容

- **bot**: `POST /auth/line` を既存 `api` 関数に追加。LIFF の ID トークンを LINE の verify API(`oauth2/v2.1/verify`)で検証し(`aud=自チャンネル` / `iss=access.line.me` / `exp` 未経過 / `sub` 必須)、`getOrCreateAppUidForLineId` で安定 appUid を解決 → `createCustomToken(appUid, { lineId: sub })` を返す。レート制限・CORS 許可リスト・タイムアウト付き、生トークン非ログ。
- **web**: `@line/liff` を追加。`web/lib/lineAuth.ts` の `initLineAuth()` が LINE ログイン → ID トークン → `/auth/line` → `signInWithCustomToken`。`useLineAuth()` を `onAuthStateChanged` + カスタムクレーム駆動に書き換え、**URL lineId 信頼を全廃**。各データフックは検証済みクレームの lineId で従来どおり `where('lineId','==',…)`。
- **フェイルセーフ**: `NEXT_PUBLIC_LIFF_ID` 未設定時は匿名サインイン(lineId クレームなし=データ0)。URL lineId には決してフォールバックしない。

## 🔧 変更種別

- [x] 🔒 セキュリティ (Security)
- [x] ✨ 新機能 (New feature)

## 🧪 テスト

- [x] `npm run build --workspace=bot`(tsc)成功
- [x] `npm run build --workspace=web` 成功 / `npx tsc --noEmit` エラー0 / `npm run lint --workspace=web` exit 0
- [ ] **実機スモーク未実施**: LIFF の login/getIDToken → verify 往復 → `signInWithCustomToken` はチャンネル作成後に要確認(下記ランブック)

## 🔑 契約(rules PR と一致)

`auth.currentUser.uid = appUid` / カスタムクレーム `lineId = 検証済み LINE userId`。rules 側はこの `request.auth.token.lineId` で所有者判定します。

## 🚀 デプロイ・ランブック(順序厳守)

1. **LINE Developers で LINE ログインチャンネル + LIFF アプリを作成**(エンドポイント= web URL)。
2. env 設定: web `NEXT_PUBLIC_LIFF_ID` / `NEXT_PUBLIC_AUTH_ENDPOINT`(既定は `https://us-central1-line-kakeibo-0410.cloudfunctions.net/api/auth/line`、実 URL を確認)、bot Secret `LINE_LIFF_CHANNEL_ID`。必要なら `WEB_ORIGINS`。
3. 本PRをマージ/デプロイ(`api` 関数の再デプロイ + Vercel)。
4. 本番で LINE ログイン→支出表示のスモークテスト。
5. **確認後に** rules ロックダウンPRをデプロイ。

## ⚠️ 注意事項

- **env(特に `NEXT_PUBLIC_LIFF_ID`)を設定せずに本番デプロイすると、web は匿名になり全ユーザーでデータが表示されません。** 手順2を必ず先に。
- 既知の残課題(rules PR に記載): グループ支出の read は現状「サインイン済みなら可」まで。世帯単位の厳密なメンバーシップ判定は `groupMembers` の決定的ID化(フォローアップ)で対応可能。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkMJz2nesZ2G4xmmS7mh7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkMJz2nesZ2G4xmmS7mh7H)_