### PR TITLE
fix(security): Firestore/Storage セキュリティルールを認証・所有者ベースに厳格化

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,49 +1,132 @@
 rules_version = '2';
+
+// ============================================================================
+// Firestore セキュリティルール — 認証・所有者ベース
+// ----------------------------------------------------------------------------
+// 認証モデル（LIFF→Firebase カスタムトークン認証 PR と対応。契約を変更しない）:
+//   - request.auth.uid            = 安定した Firebase アプリ UID（appUid）
+//   - request.auth.token.lineId   = 検証済みの LINE userId（カスタムクレーム）
+// 既存ドキュメントは各ドキュメントの `lineId` フィールドで所有者を表す。
+// したがって所有者判定 = 「サインイン済み かつ resource.data.lineId == token.lineId」。
+// 匿名フォールバックのユーザーは request.auth != null だが lineId クレームを持たない
+// ため、所有者判定・doc-id 判定の双方に一致せず、フェイルセーフに拒否される。
+//
+// 重要: サーバー側の Bot は Firebase Admin SDK を使用しており、Admin SDK は
+// これらのルールを完全にバイパスする。したがって Bot 経由の書き込み
+// （グループ作成・メンバー管理・立替精算・カテゴリ等）はここで拒否しても影響しない。
+// ============================================================================
+
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Expenses collection - LINE ID based access control
+
+    // ---- ヘルパー -----------------------------------------------------------
+    function isSignedIn() {
+      return request.auth != null;
+    }
+    // 検証済み LINE userId（カスタムクレーム）。未サインイン/匿名では null 相当。
+    function myLineId() {
+      return request.auth.token.lineId;
+    }
+    // 既存ドキュメントの所有者か（lineId フィールド一致）。
+    function ownsDoc() {
+      return isSignedIn() && resource.data.lineId == myLineId();
+    }
+    // これから書き込むドキュメントの lineId が自分のものか。
+    function writingAsSelf() {
+      return isSignedIn() && request.resource.data.lineId == myLineId();
+    }
+
+    // ---- expenses -----------------------------------------------------------
+    // 支出。個人支出は lineId フィールドで所有者を持つ。グループ支出は
+    // lineGroupId / groupId フィールドを併せ持つ。
     match /expenses/{expenseId} {
-      // Allow read/write access to documents
-      // Since we're using LINE ID only authentication, we allow access
-      // Security is handled by the web app URL parameter validation
-      allow read, write: if true;
-      allow create: if true;
+      // read:
+      //   - 所有者（resource.data.lineId == myLineId()）は常に読める。
+      //   - グループ支出（lineGroupId もしくは groupId を持つ）はサインイン済みなら読める。
+      // 【限界】グループのメンバーシップは groupMembers コレクションで表現されるが、
+      //   groupMembers ドキュメントは .add() による自動生成 ID で作られており、
+      //   決定的なドキュメントパスが存在しない。Firestore ルールは他コレクションへの
+      //   「クエリ」ができず exists()/get() は決定的パスしか辿れないため、
+      //   「呼び出し元が当該グループのメンバーか」をルール内で厳密に検証できない。
+      //   よって現状はグループ支出の read を isSignedIn() まで緩めている
+      //   （＝サインイン済みの任意ユーザーが任意のグループ支出を読める余地が残る）。
+      //   将来 groupMembers を決定的 ID（例: `${groupId}_${lineId}`）へ移行すれば、
+      //   exists(/databases/$(database)/documents/groupMembers/$(...)) で厳密化できる。
+      allow read: if ownsDoc()
+                  || (isSignedIn()
+                      && (resource.data.lineGroupId != null || resource.data.groupId != null));
+
+      // create: サインイン済みで、自分の lineId を持つドキュメントのみ作成可。
+      allow create: if writingAsSelf();
+
+      // update: 既存ドキュメントの所有者のみ。所有権の付け替え（lineId 変更）は禁止。
+      allow update: if ownsDoc() && writingAsSelf();
+
+      // delete: 既存ドキュメントの所有者のみ。
+      allow delete: if ownsDoc();
     }
-    
-    // UserLinks collection - users can only access their own linking data
-    match /userLinks/{uid} {
-      allow read, write: if request.auth != null && request.auth.uid == uid;
-    }
-    
-    // LinkTokens collection - for account linking process only
-    match /linkTokens/{tokenId} {
-      allow read, write: if true;
-      // Write operations handled by Cloud Functions only
-    }
-    
-    // Groups collection - shared household budget groups
+
+    // ---- groups -------------------------------------------------------------
+    // 共有家計グループ。createdBy に作成者の LINE userId を持つ。
+    // 作成・参加・メンバー追加は Bot（Admin SDK）が行い、ルールをバイパスする。
     match /groups/{groupId} {
-      allow read, write: if true;
+      // read: サインイン済み。
+      // 【限界】メンバーシップを決定的に検証できない（groupMembers が自動生成 ID）ため、
+      //   read はサインイン済みまで緩める（inviteCode 等も読める余地が残る）。
+      allow read: if isSignedIn();
+      // create: 作成者を自分に設定する場合のみ。
+      allow create: if isSignedIn() && request.resource.data.createdBy == myLineId();
+      // update, delete: 作成者本人のみ。
+      allow update, delete: if isSignedIn() && resource.data.createdBy == myLineId();
     }
-    
-    // Group members collection - group membership management
+
+    // ---- groupMembers -------------------------------------------------------
+    // グループメンバーシップ。lineId フィールドでメンバー本人を表す。
+    // メンバー追加・更新は Bot（Admin SDK）が行い、ルールをバイパスする。
     match /groupMembers/{memberId} {
-      allow read, write: if true;
-    }
-    
-    // User settings collection
-    match /userSettings/{userId} {
-      allow read, write: if true;
+      // read: サインイン済み。
+      // 【限界】useGroupMembers は groupId でグループ全員分を読むため、
+      //   他メンバー（別 lineId）のドキュメントも返る。よって read を
+      //   resource.data.lineId == myLineId() に絞るとクエリ全体が拒否される。
+      //   決定的なメンバーシップ検証ができないため isSignedIn() まで緩める。
+      allow read: if isSignedIn();
+      // create: 自分の lineId のメンバーシップのみ作成可。
+      allow create: if writingAsSelf();
+      // update, delete: 自分のメンバーシップのみ。
+      allow update, delete: if ownsDoc();
     }
 
-    // Budget settings collection
-    match /budgetSettings/{userId} {
-      allow read, write: if true;
+    // ---- userSettings / budgetSettings / dateRangeSettings ------------------
+    // いずれもドキュメント ID = 利用者の LINE userId（web は user.uid=lineId を doc-id に使う）。
+    // 自分の設定ドキュメントのみ read/write 可。
+    match /userSettings/{lineId} {
+      allow read, write: if isSignedIn() && lineId == myLineId();
+    }
+    match /budgetSettings/{lineId} {
+      allow read, write: if isSignedIn() && lineId == myLineId();
+    }
+    match /dateRangeSettings/{lineId} {
+      allow read, write: if isSignedIn() && lineId == myLineId();
     }
 
-    // Date range settings collection
-    match /dateRangeSettings/{userId} {
-      allow read, write: if true;
+    // ---- userLinks ----------------------------------------------------------
+    // appUid → lineId のリンク。ドキュメント ID = appUid。本人のみ。
+    match /userLinks/{uid} {
+      allow read, write: if isSignedIn() && request.auth.uid == uid;
+    }
+
+    // ---- linkTokens ---------------------------------------------------------
+    // アカウント連携トークン。Bot（Admin SDK）のみが読み書きし、Admin SDK は
+    // ルールをバイパスする。クライアントからのアクセスは全面禁止。
+    match /linkTokens/{tokenId} {
+      allow read, write: if false;
+    }
+
+    // ---- デフォルト拒否 ------------------------------------------------------
+    // 明示的に許可されていないすべてのパス（userCustomCategories / categoryFeedback
+    // など Bot/Admin SDK 専用コレクションを含む）はクライアントから拒否する。
+    match /{document=**} {
+      allow read, write: if false;
     }
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,9 +1,29 @@
 rules_version = '2';
+
+// ============================================================================
+// Cloud Storage セキュリティルール — 認証必須
+// ----------------------------------------------------------------------------
+// レシート画像は receipts/{expenseId}/{fileName} に保存される。
+// read/write ともにサインイン（Firebase Auth）を必須とする。
+//
+// 【限界】expense 単位の所有者検証（当該レシートが呼び出し元の支出のものか）は、
+//   Firestore の expenses ドキュメントを参照しないと判定できないが、Storage ルール
+//   から Firestore への安価なルックアップ手段はない。したがって
+//   「サインイン済み」を現実的なゲートとする。
+// ============================================================================
+
 service firebase.storage {
   match /b/{bucket}/o {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
     match /receipts/{expenseId}/{fileName} {
-      allow read: if true;
-      allow write: if request.resource.size < 10 * 1024 * 1024
+      // read: サインイン済みのみ（従来の `if true` を廃止）。
+      allow read: if isSignedIn();
+      // write: サインイン済み、かつ従来のサイズ/コンテンツタイプ制約を維持。
+      allow write: if isSignedIn()
+                   && request.resource.size < 10 * 1024 * 1024
                    && request.resource.contentType.matches('image/.*');
     }
   }

--- a/test/firestore.rules.test.mjs
+++ b/test/firestore.rules.test.mjs
@@ -1,0 +1,130 @@
+// Firestore セキュリティルールのユニットテスト（参考・任意実行）。
+// テスト用ツール（firebase-tools / @firebase/rules-unit-testing）は依存肥大化・
+// 監査影響を避けるため package.json には含めていない。実行する場合はアドホックに:
+//   npm i -D @firebase/rules-unit-testing firebase-tools
+//   npx firebase emulators:exec --only firestore "node test/firestore.rules.test.mjs"
+// （Java + Firestore エミュレータが必要。リポジトリ直下の firestore.rules を読み込んで検証する）
+// 本ルールはこのテスト23ケース（未認証拒否 / 他人の lineId 拒否 / lineId 不一致 create 拒否 等）
+// が全て pass することを確認済み。
+import {
+  initializeTestEnvironment,
+  assertFails,
+  assertSucceeds,
+} from '@firebase/rules-unit-testing';
+import { readFileSync } from 'node:fs';
+import {
+  doc, getDoc, setDoc, updateDoc, deleteDoc, collection, query, where, getDocs,
+} from 'firebase/firestore';
+
+// emulators:exec はリポジトリ直下（firebase.json のある場所）で実行される。
+const RULES = 'firestore.rules';
+const EMU = (process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8080').split(':');
+
+let passed = 0, failed = 0;
+async function test(name, fn) {
+  try { await fn(); passed++; console.log('  ok  -', name); }
+  catch (e) { failed++; console.error('  FAIL-', name, '\n       ', e.message); }
+}
+
+const env = await initializeTestEnvironment({
+  projectId: 'demo-kakeibo',
+  firestore: { rules: readFileSync(RULES, 'utf8'), host: EMU[0], port: Number(EMU[1]) },
+});
+
+// ルールを無効化してシードデータを投入。
+await env.withSecurityRulesDisabled(async (ctx) => {
+  const db = ctx.firestore();
+  await setDoc(doc(db, 'expenses/expA'), { lineId: 'A', amount: 100, date: '2026-08-01' });
+  await setDoc(doc(db, 'expenses/expB'), { lineId: 'B', amount: 200, date: '2026-08-01' });
+  await setDoc(doc(db, 'expenses/expG'), { lineId: 'B', lineGroupId: 'G1', amount: 300, date: '2026-08-01' });
+  await setDoc(doc(db, 'budgetSettings/A'), { monthlyBudget: 1000 });
+  await setDoc(doc(db, 'budgetSettings/B'), { monthlyBudget: 2000 });
+  await setDoc(doc(db, 'linkTokens/t1'), { lineId: 'A' });
+  await setDoc(doc(db, 'userLinks/appuid-A'), { lineId: 'A' });
+});
+
+const unauth = env.unauthenticatedContext().firestore();
+// サインイン済み（lineId カスタムクレームあり）。
+const userA = env.authenticatedContext('appuid-A', { lineId: 'A' }).firestore();
+const userB = env.authenticatedContext('appuid-B', { lineId: 'B' }).firestore();
+// 匿名フォールバック: サインイン済みだが lineId クレームなし。
+const anon = env.authenticatedContext('anon-uid', {}).firestore();
+
+console.log('Firestore rules tests:');
+
+// --- 契約で必須の3ケース -------------------------------------------------
+await test('(a) unauthenticated read of expenses is DENIED', async () => {
+  await assertFails(getDoc(doc(unauth, 'expenses/expA')));
+});
+await test('(b) userA (lineId=A) can read own expense', async () => {
+  await assertSucceeds(getDoc(doc(userA, 'expenses/expA')));
+});
+await test('(b) userA canNOT read userB expense (lineId=B)', async () => {
+  await assertFails(getDoc(doc(userA, 'expenses/expB')));
+});
+await test('(c) create with mismatched lineId is DENIED', async () => {
+  await assertFails(setDoc(doc(userA, 'expenses/newX'), { lineId: 'B', amount: 5, date: '2026-08-02' }));
+});
+
+// --- 追加ケース ----------------------------------------------------------
+await test('create with own lineId is ALLOWED', async () => {
+  await assertSucceeds(setDoc(doc(userA, 'expenses/newA'), { lineId: 'A', amount: 5, date: '2026-08-02' }));
+});
+await test('anonymous (no lineId claim) canNOT read a personal expense', async () => {
+  await assertFails(getDoc(doc(anon, 'expenses/expA')));
+});
+await test('group expense readable by signed-in non-owner (documented limitation)', async () => {
+  await assertSucceeds(getDoc(doc(userA, 'expenses/expG')));
+});
+await test('owner can update own expense', async () => {
+  await assertSucceeds(updateDoc(doc(userA, 'expenses/expA'), { amount: 111 }));
+});
+await test('non-owner canNOT update expense', async () => {
+  await assertFails(updateDoc(doc(userA, 'expenses/expB'), { amount: 999 }));
+});
+await test('owner canNOT reassign ownership (change lineId)', async () => {
+  await assertFails(updateDoc(doc(userA, 'expenses/expA'), { lineId: 'B' }));
+});
+await test('owner can delete own expense', async () => {
+  await assertSucceeds(deleteDoc(doc(userA, 'expenses/expA')));
+});
+await test('non-owner canNOT delete expense', async () => {
+  await assertFails(deleteDoc(doc(userA, 'expenses/expB')));
+});
+await test('query where lineId==A succeeds for userA', async () => {
+  await assertSucceeds(getDocs(query(collection(userA, 'expenses'), where('lineId', '==', 'A'))));
+});
+await test('query where lineGroupId==G1 succeeds for signed-in user', async () => {
+  await assertSucceeds(getDocs(query(collection(userA, 'expenses'), where('lineGroupId', '==', 'G1'))));
+});
+await test('budgetSettings: userA reads own (doc id == lineId)', async () => {
+  await assertSucceeds(getDoc(doc(userA, 'budgetSettings/A')));
+});
+await test('budgetSettings: userA canNOT read B doc', async () => {
+  await assertFails(getDoc(doc(userA, 'budgetSettings/B')));
+});
+await test('budgetSettings: userA can write own doc', async () => {
+  await assertSucceeds(setDoc(doc(userA, 'budgetSettings/A'), { monthlyBudget: 1234 }));
+});
+await test('budgetSettings: userA canNOT write B doc', async () => {
+  await assertFails(setDoc(doc(userA, 'budgetSettings/B'), { monthlyBudget: 9 }));
+});
+await test('linkTokens: signed-in read DENIED (admin-only)', async () => {
+  await assertFails(getDoc(doc(userA, 'linkTokens/t1')));
+});
+await test('linkTokens: signed-in write DENIED (admin-only)', async () => {
+  await assertFails(setDoc(doc(userA, 'linkTokens/t2'), { lineId: 'A' }));
+});
+await test('userLinks: user can read own (uid match)', async () => {
+  await assertSucceeds(getDoc(doc(userA, 'userLinks/appuid-A')));
+});
+await test('userLinks: user canNOT read other uid', async () => {
+  await assertFails(getDoc(doc(userB, 'userLinks/appuid-A')));
+});
+await test('default-deny: unknown collection read DENIED', async () => {
+  await assertFails(getDoc(doc(userA, 'userCustomCategories/x')));
+});
+
+await env.cleanup();
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## 🔒 背景(修正する脆弱性)

`firestore.rules` は expenses / groups / groupMembers / budgetSettings / userSettings / dateRangeSettings / linkTokens が **`allow read, write: if true`**、`storage.rules` も受領画像が誰でも読み書き可でした。これはアプリ認証とは独立した**真の穴**で、公開 Firebase 設定を持つ任意のクライアントが**全ユーザーのデータを読み取り・改ざん・削除**できます。

本PRは rules を **Firebase Auth 必須 + 所有者ベース**に全面書き換えします。

## 📋 変更内容

- 認証モデル(auth PR #156 と一致): `request.auth.uid = appUid` / `request.auth.token.lineId = 検証済み LINE userId`。所有者判定 = `resource.data.lineId == token.lineId`。
- **expenses**: read=所有者(+グループ支出は下記限界によりサインイン済み)、create=自分の lineId、update/delete=所有者のみ・所有権付け替え禁止。
- **設定系**(userSettings/budgetSettings/dateRangeSettings): doc-id == 自分の lineId のみ。
- **linkTokens**: クライアント全面禁止(Admin SDK はバイパス)。**userLinks**: 本人 uid のみ。末尾に **default-deny**。
- **storage**: receipts は read/write ともにサインイン必須(サイズ/画像タイプ制約は維持)。
- 検証: `@firebase/rules-unit-testing` + エミュレータで **23 ケース pass**(未認証拒否 / 他人 lineId 拒否 / lineId 不一致 create 拒否 等)。テスト用の重い依存はコミットに含めず(監査影響回避)、`test/firestore.rules.test.mjs` を参考同梱(実行方法はファイル冒頭に記載)。

## 🔧 変更種別

- [x] 🔒 セキュリティ (Security)

## ⚠️ 既知の限界(フォローアップ候補)

`groupMembers` が `.add()` の**自動生成ID**でメンバーシップを表すため、rules 内で決定的な `exists()`/`get()` によるメンバー判定ができません。そのため**グループ支出/グループ/メンバーの read は「サインイン済みなら可」まで緩和**しています(未認証 `if true` からは大幅改善だが、サインイン済みの任意ユーザーが任意グループの支出を読める余地は残る)。本アプリの主用途は世帯共有のため、次段で **`groupMembers` を決定的ID(`${groupId}_${lineId}`)へ移行 + bot 側の書き込み変更 + 既存データ移行**を行い、`exists()` によるメンバー限定 read に厳密化することを推奨します(データ移行を伴うため本PRとは分離)。

## 🚀 デプロイ順序(厳守)

**本ルールは auth PR #156 が本番稼働し、実ユーザーが `request.auth` + `lineId` クレームを得られる状態になった後に限りデプロイしてください。** 先に適用すると全ユーザーのデータアクセスが不能になります。そのため本PRはドラフトにしています。

## 🧪 テスト

- [x] エミュレータでルールユニットテスト 23 ケース pass(ルール構文の妥当性も確認)
- [ ] `firebase deploy --only firestore:rules --dry-run` はプロジェクト認証が必要なため未実施(エミュレータ検証で代替)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkMJz2nesZ2G4xmmS7mh7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkMJz2nesZ2G4xmmS7mh7H)_