### PR TITLE
fix(ci): storage.rules を firebase deploy の対象に追加

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,7 +35,7 @@ jobs:
             web:
               - 'web/**'
               - '.github/workflows/**'
-            # deploy-bot は functions に加えて firestore の rules / indexes も
+            # deploy-bot は functions に加えて firestore / storage の rules も
             # デプロイするため、それらの定義ファイルも検知対象に含める。
             bot:
               - 'bot/**'
@@ -44,6 +44,7 @@ jobs:
               - '.firebaserc'
               - 'firestore.rules'
               - 'firestore.indexes.json'
+              - 'storage.rules'
             deps:
               - 'package*.json'
               - 'package-lock.json'
@@ -266,7 +267,7 @@ jobs:
       - name: Deploy to Firebase
         run: |
           npm install -g firebase-tools@15
-          firebase deploy --only functions,firestore:rules,firestore:indexes --project "$FIREBASE_PROJECT_ID"
+          firebase deploy --only functions,firestore:rules,firestore:indexes,storage --project "$FIREBASE_PROJECT_ID"
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
           # 未設定時のフォールバック（空文字を渡すと deploy が落ちるため）


### PR DESCRIPTION
## 📋 変更内容

ci-cd の deploy-bot ジョブで `firebase deploy` の `--only` に `storage` を追加し、path filter にも `storage.rules` を追加します(2行の変更)。

## 🎯 目的・背景

#157 で `storage.rules` を厳格化(レシート画像の read/write をサインイン必須化)しましたが、現行 CI の deploy コマンドは `--only functions,firestore:rules,firestore:indexes` で **storage を含んでおらず、厳格化した storage.rules が本番に反映されません**(旧・全公開ルールが残り続ける)。本PRで CI 経由の自動デプロイに乗せます。

`firebase.json` には `"storage": { "rules": "storage.rules" }` のマッピングが定義済みのため、`--only storage` はそのまま機能します。

## 🔧 変更種別

- [x] 🔒 セキュリティ (Security)
- [x] 🔧 設定・ツール (Configuration/Tools)

## 🧪 テスト

- [x] `firebase.json` に storage マッピングが存在することを確認
- [x] 変更は deploy コマンドの対象追加と path filter のみ(ビルドへの影響なし)

## ⚠️ 注意事項

- マージすると次回の deploy-bot 実行で厳格化済み storage.rules が本番反映され、**未サインインのレシート画像アクセスが遮断**されます(#157 の適用判断と整合)。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkMJz2nesZ2G4xmmS7mh7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkMJz2nesZ2G4xmmS7mh7H)_