### PR TITLE
fix(ci): デプロイ経路の不備を修正（認証情報の無検証 / Vercel の誤アップロード・誤プロジェクト）

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -238,6 +238,19 @@ jobs:
     environment:
       name: production-bot
     steps:
+      # secrets コンテキストは job-level の `if:` から参照できない（常に空扱いに
+      # なる）ため、ジョブ内の最初のステップで明示的に検証する。未設定のまま
+      # 進むと google-github-actions/auth が分かりにくいエラーで落ちる。
+      - name: Verify Google Cloud credentials are configured
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        run: |
+          if [ -z "$GCP_SA_KEY" ]; then
+            echo "::error::GCP_SA_KEY が production-bot environment に設定されていません。Firebase への自動デプロイは実行できません。"
+            exit 1
+          fi
+          echo "✅ GCP_SA_KEY is configured"
+
       - name: Checkout code
         uses: actions/checkout@v4
         

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,26 @@
+# 秘密値（.gitignore は Vercel のアップロードに効かないため明示的に除外する）
+.env
+.env.*
+*.b64
+credentials.json
+**/credentials.json
+service-account*.json
+kakeibo_service.json
+vision-key.json
+
+# 巨大なローカル資材（デプロイに不要）
+google-cloud-sdk
+google-cloud-*.tar.gz
+
+# 依存とビルド成果物（Vercel 側でインストール／ビルドする）
+node_modules
+**/node_modules
+.next
+**/.next
+dist
+**/dist
+
+# その他
+.git
+.firebase
+*.log

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,7 +1,13 @@
 # 秘密値（.gitignore は Vercel のアップロードに効かないため明示的に除外する）
+# .gitignore が「秘密値を含みうる」として扱っているパターンをすべてミラーする。
+# ルートからデプロイするため、ここに漏れがあるとそのまま流出経路になる。
 .env
 .env.*
 *.b64
+*.incoming
+*.bak
+*.secret.json
+*.local.json
 credentials.json
 **/credentials.json
 service-account*.json

--- a/deploy-vercel.sh
+++ b/deploy-vercel.sh
@@ -14,13 +14,17 @@ if ! command -v vercel >/dev/null 2>&1; then
   exit 1
 fi
 
-# .vercelディレクトリの存在確認（web 配下で実施）
-if [ ! -d web/.vercel ] || [ ! -s web/.vercel/project.json ]; then
-  echo "⚠️ Vercel プロジェクトにリンクされていません（web）。リンクを作成します..."
-  vercel link --yes --cwd web
+# Vercel プロジェクトリンクの確認（リポジトリルートで実施）
+# 本番 https://line-kakeibo.vercel.app を配信しているのはルートにリンクした
+# `line-kakeibo` プロジェクト。ルートの vercel.json が
+# buildCommand='cd web && npm run build' / outputDirectory='web/.next' を
+# 定義しているため、デプロイもルートから実行する必要がある。
+if [ ! -d .vercel ] || [ ! -s .vercel/project.json ]; then
+  echo "⚠️ Vercel プロジェクトにリンクされていません。リンクを作成します..."
+  vercel link --yes --project line-kakeibo --scope makoto041s-projects
 fi
 
-echo "✅ Vercel CLI および（web ディレクトリの）プロジェクトリンクの確認が完了しました。"
+echo "✅ Vercel CLI およびプロジェクトリンクの確認が完了しました。"
 
 # 環境変数ファイルの確認
 if [ ! -f web/.env.local ]; then
@@ -51,24 +55,14 @@ npm run build
 # プロジェクトルートに戻る
 cd ..
 
-# Vercel に環境変数を設定（必要に応じて）
-echo "🔐 Vercel環境変数を設定中..."
+# 環境変数は Vercel ダッシュボード（Project Settings > Environment Variables）で
+# 管理する。以前はここで web/.env.local の全キーを `vercel env add` に流していたが、
+# ローカルの秘密値を機械的に本番へ push してしまううえ、リンク先プロジェクトが
+# ずれていると誤ったプロジェクトへ書き込む事故になるため廃止した。
 
-# web/.env.localから環境変数を読み込んで設定
-while IFS='=' read -r key value; do
-  # 空行やコメント行はスキップ
-  if [[ -z "$key" || "$key" == \#* ]]; then
-    continue
-  fi
-
-  # Vercelに環境変数を追加（エラーを無視）
-  echo "Setting $key..."
-  echo "$value" | vercel env add "$key" production --cwd web 2>/dev/null || true
-done <web/.env.local
-
-# Vercel production デプロイ
-echo "🚀 Vercel に production モードでデプロイを実行中... (tgz アーカイブ + web ディレクトリ)"
-vercel --prod --archive=tgz --cwd web --yes
+# Vercel production デプロイ（リポジトリルートから実行）
+echo "🚀 Vercel に production モードでデプロイを実行中... (tgz アーカイブ)"
+vercel --prod --archive=tgz --yes
 
 echo "✅ デプロイが完了しました！"
 echo "📖 デプロイされたURLを確認してください。"

--- a/web/lib/firebase.ts
+++ b/web/lib/firebase.ts
@@ -174,22 +174,29 @@ const testFirebaseConnection = async () => {
     console.log('✅ Firebase connection test successful');
     return true;
   } catch (error) {
-    console.error('❌ Firebase connection test failed:', error);
-    
-    // エラーの種類に応じた対処法を提示
     const firestoreError = error as { code?: string };
+
+    // permission-denied はリクエストがバックエンドに到達し、ルールに評価された
+    // 証拠なので、接続テストとしては成功扱いにする。
+    // このプローブは無フィルタの `expenses` クエリであり、所有者ベースのルール
+    // （resource.data.lineId == token.lineId）を構造的に満たせないため、
+    // ルールが正しく機能している限り必ずここに来る。
     if (firestoreError?.code === 'permission-denied') {
-      console.info(
-        '📝 Firestore Security Rules may be blocking access.\n' +
-        'Please check your Firestore rules in Firebase Console.'
+      console.log(
+        '✅ Firebase connection test successful (probe query rejected by Security Rules, which confirms reachability)'
       );
-    } else if (firestoreError?.code === 'unavailable') {
+      return true;
+    }
+
+    console.error('❌ Firebase connection test failed:', error);
+
+    if (firestoreError?.code === 'unavailable') {
       console.info(
         '📝 Firestore service is unavailable.\n' +
         'Please check your internet connection and Firebase project status.'
       );
     }
-    
+
     return false;
   }
 };


### PR DESCRIPTION
## 🎯 背景

PR #156（LIFF 認証）/ #157（Firestore・Storage ルールのロックダウン）を本番適用する作業のなかで、**デプロイ経路そのものが複数箇所で壊れている**ことが判明した。実際に #156 のマージでは bot も web も自動デプロイされず、すべて手動デプロイで本番反映している。本PRはその原因をコード側でまとめて塞ぐ。

> **注**: 当初は storage ルールのデプロイ対象漏れも含めていたが、同内容が #158 で先にマージされたため本PRからは除外し、rebase 済み。

## 📋 変更内容

### `.github/workflows/ci-cd.yml` — `GCP_SA_KEY` の存在検証

`deploy-bot` の先頭に検証ステップを追加する。未設定のまま進むと `google-github-actions/auth` が

```
the GitHub Action workflow must specify exactly one of "workload_identity_provider" or "credentials_json"
```

という原因の分かりにくいエラーで落ちる（#156 のマージで実際に発生し、bot が自動デプロイされなかった）。

`secrets` コンテキストは **job-level の `if:` から参照できず常に空として評価される**ため、`if: ${{ secrets.GCP_SA_KEY != '' }}` と書くとジョブが黙ってスキップされ発見がさらに遅れる。そのためジョブ内の最初のステップで検証している。

### `.vercelignore`（新規）

Vercel CLI は `.gitignore` を参照しないため、`google-cloud-sdk/`（1.6GB）と tarball 2つ（計 236MB）までアップロード対象になり、**転送量が 477MB** になっていた（追加後は 1.1MB）。`.env` 系も明示的に除外し、ローカルの秘密値が Vercel のビルド環境へ上がらないようにしている。

### `deploy-vercel.sh`

- 本番 `https://line-kakeibo.vercel.app` を配信しているのは**ルートにリンクした `line-kakeibo` プロジェクト**だが、本スクリプトは `--cwd web` で `web/.vercel`（別プロジェクト ID を指す）を使っていた。ルートから `line-kakeibo` へデプロイするよう修正。ルートの `vercel.json` が `buildCommand='cd web && npm run build'` を定義しているため、デプロイもルートから実行する必要がある。
- **`web/.env.local` の全キーを `vercel env add` へ流し込むループを削除**。ローカルの秘密値を機械的に本番へ push するうえ、リンク先がずれていると誤ったプロジェクトへ書き込む事故になる。環境変数は Vercel ダッシュボードで管理する。

### `web/lib/firebase.ts`

接続テストの `permission-denied` を**成功扱い**に変更。このプローブは無フィルタの `expenses` クエリで、#157 の所有者ベースのルール（`resource.data.lineId == token.lineId`）を構造的に満たせないため、**ルールが正しく機能している限り必ず拒否される**。リクエストがバックエンドに到達しルールに評価された証拠なので、接続テストとしては成功。`unavailable` などの本物の接続障害は従来どおり失敗として扱う。

## 🔧 変更種別

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔒 セキュリティ (秘密値の誤アップロード経路を塞ぐ)

## 🧪 テスト

- [x] `npx tsc --noEmit`（web）エラー 0
- [x] `npm -w web run lint` エラー 0（警告 23 件はすべて既存。変更ファイル由来は 0 件）
- [x] `npm -w web run build` 成功
- [x] `npm -w bot run build` 成功
- [x] `bash -n deploy-vercel.sh` 構文チェック通過
- [x] `.vercelignore` 追加後の実アップロードが 477MB → 1.1MB になることを本番デプロイで確認済み

## ⚠️ 本PRだけでは自動デプロイは復旧しない（リポジトリ外の作業が必要）

コードで直せない設定が2つ残る。**どちらもリポジトリ管理者の操作が必要**:

1. **`GCP_SA_KEY` を GitHub の `production-bot` environment に設定する。** 現在未設定のため bot の自動デプロイができない。本PR適用後は、その旨が明示的なエラーメッセージで表示されるようになる。
2. **Vercel の Git 連携を再接続する。** `vercel-deploy.yml` は「Vercel の Git 連携がネイティブに実行する」前提の no-op だが、実際には連携が発火しておらず、master へマージしても web がデプロイされない。リポジトリルートで `vercel git connect` が最も手軽。

なお本PRは `.github/workflows/**` を変更するため、マージ時の master push で `deploy-bot` が起動し、**上記1が未設定の間は新しい検証ステップで意図的に失敗する**（これが本PRの狙いどおりの挙動）。

## 📌 残タスク（本PR対象外）

`groupMembers` の決定的ID化（`${groupId}_${lineId}`）+ bot 側の書き込み変更 + データ移行。これができるまで #157 のグループ支出 read は「サインイン済みなら誰でも可」までしか絞れない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GcXZLvy359vkTHoQUDbx2
