### PR TITLE
fix(ci): bot ビルド成果物の展開先を bot/dist に修正

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -264,7 +264,12 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: bot-build
-          path: bot/
+          # upload 側は `path: bot/dist` なので、アーティファクトのルートには
+          # dist の「中身」が入る（共通パスが剥がされる仕様）。ここで `bot/` に
+          # 展開すると bot/index.js になり、bot/package.json の
+          # main=dist/index.js と食い違って
+          # 「bot/dist/index.js does not exist」でデプロイが落ちる。
+          path: bot/dist
 
       # firebase deploy は関数の一覧を取得するために bot/ のコードを実際に読み込む。
       # 成果物（dist）だけでは依存が解決できないため、ワークスペース全体を入れる。


### PR DESCRIPTION
## 🎯 背景

PR #159 で `GCP_SA_KEY` の存在検証を入れ、secret を設定したうえで `deploy-bot` を再実行したところ、認証・ルールのコンパイルまでは通過するようになったが、次の段階で失敗した:

```
Error: There was an error reading bot/package.json:
 bot/dist/index.js does not exist, can't deploy Cloud Functions
```

## 🐛 原因

ビルド成果物の受け渡しで、アップロード側とダウンロード側のパス指定が食い違っている。

| | 指定 | 結果 |
|---|---|---|
| upload-artifact | `path: bot/dist` | 共通パスが剥がされ、アーティファクトの**ルートに dist の中身**が入る |
| download-artifact | `path: bot/` | `bot/index.js` として展開される |

`bot/package.json` の `main` は `dist/index.js` なので、firebase がエントリポイントを見つけられずデプロイが落ちる。

`actions/upload-artifact` が指定パスの共通祖先を剥がす仕様であることが原因で、**同種の不具合は web-build でも過去に発生している**（同ファイル 168-169 行に「.next が除外されて web-build の中身が空になり deploy-web のダウンロードが失敗していた」というコメントが残っている）。

## 📋 変更内容

download-artifact の展開先を `bot/` → `bot/dist` に修正。理由をコメントで明記した。

## 🔧 変更種別

- [x] 🐛 バグ修正 (Bug fix)

## 🧪 テスト

ワークフロー定義のみの変更のため、実行による検証はマージ後になる。本PRは `.github/workflows/**` を変更するので、マージ時の master push で `bot` フィルタに一致し `deploy-bot` が起動する。そこで実際にデプロイまで到達するかを確認する。

- [x] YAML の構造を確認（`deploy-bot` の steps 構成・インデント）
- [ ] マージ後の master push で deploy-bot がデプロイ完了まで到達すること

## 📌 補足

この不具合は `GCP_SA_KEY` 未設定によって認証段階で先に落ちていたため、これまで顕在化していなかった。#159 で認証を通したことで初めて到達した段階の問題であり、**deploy-bot がこれまで一度も成功したことがない**ことを示している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GcXZLvy359vkTHoQUDbx2
