### PR TITLE
fix(bot): 「家計簿一覧を見る」を1タップで支出一覧へ直接遷移させる

### DIFF
--- a/bot/scripts/smoke-expense-card.js
+++ b/bot/scripts/smoke-expense-card.js
@@ -103,7 +103,6 @@ function common(name, msg) {
     paymentMethod: '現金',
     payerName: 'まこと',
     includeInTotal: false,
-    webAppUrl: 'https://line-kakeibo.vercel.app?lineId=U1',
     editUrl: buildExpenseEditUrl('exp_text_1', 'U1'),
   });
   common('手入力の登録カード', msg);
@@ -137,7 +136,9 @@ function common(name, msg) {
     edit.uri
   );
   const list = actions.find((a) => a.label === '家計簿一覧を見る');
-  check('家計簿一覧は直リンク(uri)', list && list.type === 'uri');
+  check('家計簿一覧は直リンク(uri)', list && list.type === 'uri', list && list.type);
+  check('家計簿一覧の遷移先は支出一覧ページ', list && list.uri.endsWith('/expenses'), list && list.uri);
+  check('家計簿一覧URLに lineId を含まない', list && !list.uri.includes('lineId'), list && list.uri);
   check('OK は postback', actions.find((a) => a.label === 'OK').type === 'postback');
   check('日付は M/D 表記', JSON.stringify(msg).includes('"8/11"'));
 }
@@ -170,7 +171,10 @@ function common(name, msg) {
   const edit = actions.find((a) => a.label === '修正');
   check('修正は postback（押下者が未定のため）', edit && edit.type === 'postback', edit && edit.type);
   const list = actions.find((a) => a.label === '家計簿一覧を見る');
-  check('家計簿一覧も postback', list && list.type === 'postback');
+  // 本人判定が URL から Firebase の検証済みクレームへ移ったため、押下者が未定の
+  // Gmail 通知でも個人化不要の固定URLへ直接遷移できる。
+  check('家計簿一覧は直リンク(uri)', list && list.type === 'uri', list && list.type);
+  check('家計簿一覧の遷移先は支出一覧ページ', list && list.uri.endsWith('/expenses'), list && list.uri);
 }
 
 // ------------------------------------------------- 精算済み（変更不可の状態）
@@ -187,7 +191,7 @@ function common(name, msg) {
       inputSource: 'line_text',
       paymentMethod: 'unknown',
     },
-    { listUrl: 'https://line-kakeibo.vercel.app?lineId=U1', editUrl: buildExpenseEditUrl('exp_settled', 'U1') }
+    { editUrl: buildExpenseEditUrl('exp_settled', 'U1') }
   );
   common('精算済みの再構築カード', msg);
 

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -189,7 +189,7 @@ async function handleTextMessage(event: any) {
         const lineGroupId = isGroupContext ? event.source.groupId : undefined;
 
         // Generate appropriate URL based on context
-        const webAppUrl = buildExpenseListUrl(event.source.userId, lineGroupId);
+        const webAppUrl = buildExpenseListUrl();
 
         // 当月の集計データを取得（コンテナは UTC 動作のため JST で当月を決める）
         const now = nowJST();
@@ -1123,11 +1123,8 @@ async function processExpenseInBackground(
         payerName: userDisplayName,
         // 保存時の値と揃える（LINE手入力は OK を押すまで集計に入らない）
         includeInTotal: expense.includeInTotal,
-        webAppUrl: event.source.userId
-          ? buildExpenseListUrl(event.source.userId, lineGroupId)
-          : undefined,
         // 「修正」はWeb編集画面への直リンク。グループの場合カードはグループ全員に
-        // 届くため、リンクは入力した本人のIDで固定される（上の webAppUrl と同じ性質）。
+        // 届くため、リンクは入力した本人のIDで固定される。
         editUrl: event.source.userId
           ? buildExpenseEditUrl(expenseId, event.source.userId)
           : undefined,

--- a/bot/src/line/flexMessage.ts
+++ b/bot/src/line/flexMessage.ts
@@ -149,6 +149,16 @@ function iconActionButton(opts: {
 /** Webアプリのベースドメイン */
 export const WEB_APP_BASE = 'https://line-kakeibo.vercel.app';
 
+/**
+ * 「家計簿一覧を見る」の遷移先（支出一覧ページ）。
+ *
+ * LIFF ログイン導入前は、web が URL の lineId クエリで本人を判定していたため
+ * 「押した人ごとに異なるURL」を組み立てる必要があり、押下者が不明な push では
+ * postback で往復してURLを返していた。現在は web が検証済みの Firebase
+ * カスタムクレームで本人を判定するため、一覧の入口は全員共通の固定URLでよい。
+ */
+export const EXPENSE_LIST_URL = `${WEB_APP_BASE}/expenses`;
+
 /** 登録・編集カードの入力元 */
 export type ExpenseCardSource = 'gmail' | 'text';
 
@@ -371,8 +381,6 @@ function buildExpenseCard(opts: {
   includeInTotal?: boolean;
   /** 金額行の下に差し込むフロー固有の行（残り予算・支払い方法など） */
   detailRows?: FlexComponent[];
-  /** 「家計簿一覧を見る」の遷移先。未指定なら押下者のIDで解決する postback にする。 */
-  listUrl?: string;
   /** 「修正」の遷移先。未指定なら押下者のIDで解決する postback にする。 */
   editUrl?: string;
 }): FlexMessage {
@@ -388,7 +396,6 @@ function buildExpenseCard(opts: {
     status,
     includeInTotal,
     detailRows = [],
-    listUrl,
     editUrl,
   } = opts;
 
@@ -512,22 +519,16 @@ function buildExpenseCard(opts: {
           },
         }),
         // 3段目: 家計簿一覧への導線
+        // 本人判定が URL から Firebase の検証済みクレームへ移ったため、押下者が
+        // 誰であっても同じURLでよい。postback で往復せず1タップで直接開く。
         iconActionButton({
           iconKey: 'external-link',
           label: '家計簿一覧を見る',
-          action: listUrl
-            ? {
-                type: 'uri',
-                label: '家計簿一覧を見る',
-                uri: listUrl,
-              }
-            : {
-                // Gmail 通知はグループ宛の push で、押す人が誰か分からない。
-                // 押下時の userId で個人化したURLを返すため postback にする。
-                type: 'postback',
-                label: '家計簿一覧を見る',
-                data: JSON.stringify({ action: 'show_list', expenseId, source }),
-              },
+          action: {
+            type: 'uri',
+            label: '家計簿一覧を見る',
+            uri: EXPENSE_LIST_URL,
+          },
         }),
       ],
       paddingAll: 'md',
@@ -624,8 +625,6 @@ export interface TextExpenseInfo {
   status?: ExpenseStatusType;
   /** 集計に含めるか。pending のときの現在値表示に使う */
   includeInTotal?: boolean;
-  /** 「家計簿一覧を見る」の遷移先（送信相手の lineId を含むURL） */
-  webAppUrl?: string;
   /** 「修正」の遷移先（送信相手の lineId を含むWeb編集URL） */
   editUrl?: string;
 }
@@ -644,7 +643,6 @@ export function buildTextExpenseFlexMessage(info: TextExpenseInfo): FlexMessage 
     payerName,
     status,
     includeInTotal,
-    webAppUrl,
     editUrl,
   } = info;
 
@@ -672,20 +670,21 @@ export function buildTextExpenseFlexMessage(info: TextExpenseInfo): FlexMessage 
     // LINE手入力は includeInTotal: false で作られる（OK を押すまで集計に入らない）
     includeInTotal: includeInTotal ?? false,
     detailRows: detailRows as unknown as FlexComponent[],
-    listUrl: webAppUrl,
     editUrl,
   });
 }
 
 /**
- * 家計簿一覧（Webアプリ）のURLを組み立てる
+ * Webアプリ（ダッシュボード）のURLを組み立てる
  *
- * Web側の認証は lineId クエリだけを見る（無い場合はゲスト扱いでサンプル表示になる）ため、
- * 押した本人の lineId を必ず含める。
+ * かつては web が URL の lineId クエリで本人を判定していたため lineId / lineGroupId を
+ * 付与していたが、LIFF ログイン導入後の web はダッシュボード・一覧のどちらでも
+ * これらのクエリを読まない（lineGroupId は利用者自身のグループ所属から解決し、
+ * lineId を読むのは /link のアカウント連携フローのみ）。グループトークに流れる
+ * リンクに LINE userId を載せ続ける理由も無いため、クエリなしの固定URLにする。
  */
-export function buildExpenseListUrl(lineId: string, lineGroupId?: string): string {
-  const base = `${WEB_APP_BASE}?lineId=${encodeURIComponent(lineId)}`;
-  return lineGroupId ? `${base}&lineGroupId=${encodeURIComponent(lineGroupId)}` : base;
+export function buildExpenseListUrl(): string {
+  return WEB_APP_BASE;
 }
 
 /**
@@ -724,7 +723,6 @@ export function buildExpenseCardFromRecord(
   expenseId: string,
   record: ExpenseRecordLike,
   opts: {
-    listUrl?: string;
     editUrl?: string;
     headerText?: string;
     headerIconKey?: string;
@@ -764,7 +762,6 @@ export function buildExpenseCardFromRecord(
     status: record.status,
     includeInTotal: record.includeInTotal,
     detailRows: detailRows as unknown as FlexComponent[],
-    listUrl: opts.listUrl,
     editUrl: opts.editUrl,
   });
 }

--- a/bot/src/line/index.ts
+++ b/bot/src/line/index.ts
@@ -11,6 +11,7 @@ export {
   buildExpenseCardFromRecord,
   buildExpenseEditUrl,
   buildExpenseListUrl,
+  EXPENSE_LIST_URL,
   CardUsageInfo,
   // テキスト入力用
   buildTextExpenseFlexMessage,

--- a/bot/src/line/postback.ts
+++ b/bot/src/line/postback.ts
@@ -19,7 +19,7 @@ import {
   buildCategorySelectCarousel,
   buildExpenseCardFromRecord,
   buildExpenseEditUrl,
-  buildExpenseListUrl,
+  EXPENSE_LIST_URL,
   CategorySelectInfo,
 } from './flexMessage';
 
@@ -62,11 +62,6 @@ function getReplyTarget(event: PostbackEvent): string | undefined {
   return event.source!.type === 'group'
     ? (event.source as any).groupId
     : event.source!.userId;
-}
-
-/** グループから押された場合のグループID */
-function getGroupId(event: PostbackEvent): string | undefined {
-  return event.source!.type === 'group' ? (event.source as any).groupId : undefined;
 }
 
 /**
@@ -192,11 +187,9 @@ async function replyUpdatedCard(
   headerText: string
 ): Promise<void> {
   const userId = event.source!.userId;
-  const listUrl = userId ? buildExpenseListUrl(userId, getGroupId(event)) : undefined;
   const editUrl = userId ? buildExpenseEditUrl(expenseId, userId) : undefined;
 
   const card = buildExpenseCardFromRecord(expenseId, record, {
-    listUrl,
     editUrl,
     headerText,
     headerIconKey: 'check',
@@ -447,17 +440,12 @@ async function handleEdit(
 /**
  * 家計簿一覧のリンクを返す
  *
- * Web側は lineId クエリで対象ユーザーを判定するため、押した本人のIDで組み立てる。
+ * 新しいカードの「家計簿一覧を見る」は uri アクションで直接遷移するため、この
+ * postback は届かない。トーク履歴に残る過去のカードから押された場合にのみ来る
+ * ので、後方互換のために残している。
  */
 async function handleShowList(event: PostbackEvent): Promise<void> {
-  const userId = event.source!.userId;
-  if (!userId) {
-    await replyText(event, 'ユーザーを特定できなかったため、家計簿一覧を開けませんでした');
-    return;
-  }
-
-  const url = buildExpenseListUrl(userId, getGroupId(event));
-  await replyText(event, `家計簿一覧はこちら\n${url}`);
+  await replyText(event, `家計簿一覧はこちら\n${EXPENSE_LIST_URL}`);
 }
 
 /**


### PR DESCRIPTION
## 🎯 背景

LINE の支出カードにある「家計簿一覧を見る」が、Gmail 通知経由では **2段階**を踏まないと開けなかった。

1. ボタンをタップ（postback）
2. bot が「家計簿一覧はこちら + URL」というテキストを返信
3. **そのURLをもう一度タップ**

これは web の本人判定が URL の `lineId` クエリだけだった時代の制約による。Gmail 通知はグループ宛の push なので「誰が押すか」が送信時点で分からず、押下時の userId で個人化したURLを組み立てるために postback で往復していた。

**PR #156 で LIFF ログイン + Firebase カスタムクレームによる本人判定に移行したため、この制約は既に無くなっている。** URL に誰の ID が入っているかは web の挙動に一切影響しない。

## 📋 変更内容

### 1タップで直接遷移するようにした

`EXPENSE_LIST_URL`（`/expenses` への固定URL）を追加し、「家計簿一覧を見る」を常に `uri` アクションにした。押下者が誰であっても同じURLでよいため、postback で往復する必要がない。

**遷移先もボタン名に合わせて変更した。** 従来は `/`（月次サマリーとグラフのダッシュボード）に着地していたが、「家計簿一覧を見る」というラベルどおり支出一覧ページ `/expenses` へ遷移する。

### 不要になった配線を削除

押下者ごとの出し分けが不要になったことで、以下が連鎖的に不要になった:

- `buildExpenseCard` の `listUrl` プロパティと、それを各所へ配る受け渡し
- `TextExpenseInfo.webAppUrl`（一覧ボタン専用だった）
- `postback.ts` の `getGroupId`（未使用化）

### `buildExpenseListUrl` の死んだ引数を削除

`lineId` / `lineGroupId` を付与していたが、**web はダッシュボードでも一覧でもこれらのクエリを読まない**。`lineGroupId` は利用者自身のグループ所属から Firestore 経由で解決しており、URL の `lineId` を読むのは `/link` のアカウント連携フローのみ（`web/app/link/LinkClientPage.tsx:15`）。

グループトークに流れるリンクに LINE userId を載せ続ける理由も無いため、クエリなしの固定URLにした。

### 後方互換

`handleShowList`（postback ハンドラ）は**削除せず残している**。トーク履歴に残る過去のカードのボタンは postback のままなので、押されたときに固定URLを返す。

## 🔧 変更種別

- [x] ✨ 改善 (UX)
- [x] 🧹 リファクタ（不要になった配線の削除）

## 🧪 テスト

- [x] `npm -w bot run build`（tsc）成功
- [x] `npm -w bot run lint` 通過
- [ ] **実機確認はマージ・デプロイ後**: 新しく届くカードの「家計簿一覧を見る」が1タップで `/expenses` を開くこと

差分は **+33 / -50** で、追加より削除が多い。「押した人ごとに異なるURLが必要」という制約が消えたことで配線が丸ごと不要になったため。

## ⚠️ 実機確認時の注意

**トーク履歴に既にある古いカード**は postback のままなので、押すと従来どおり2段階になる。これは仕様（後方互換のため）。確認は**新しく届くカード**で行う必要がある。

## 📌 スコープ外（必要なら別途対応します）

同じカードの「修正」ボタンも同じ2段階構造を持っている（`buildExpenseEditUrl` も `lineId` を付けているが、これも web は読まない）。今回の依頼は一覧の導線だったため触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GcXZLvy359vkTHoQUDbx2
