### PR TITLE
fix(security): グループ支出を編集可能にし、匿名セッションからのグループ閲覧を塞ぐ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ build/
 # Firebase
 .firebase/
 firebase-debug.log
+# エミュレータ実行時に生成される（test/firestore.rules.test.mjs の手順）
+firestore-debug.log
+ui-debug.log
 
 # Vercel
 .vercel/

--- a/firestore.rules
+++ b/firestore.rules
@@ -23,6 +23,13 @@ service cloud.firestore {
     function isSignedIn() {
       return request.auth != null;
     }
+    // 検証済みの LINE ユーザーとしてサインインしているか。
+    // 匿名サインインは公開 API キーだけで誰でも作れるため、isSignedIn() は実質
+    // 「誰でも」と同義になる。LINE 本人確認を経たセッションだけが lineId クレームを
+    // 持つので、他人のデータに触れうる条件では必ずこちらを使うこと。
+    function isLineUser() {
+      return isSignedIn() && request.auth.token.lineId != null;
+    }
     // 検証済み LINE userId（カスタムクレーム）。未サインイン/匿名では null 相当。
     function myLineId() {
       return request.auth.token.lineId;
@@ -34,6 +41,19 @@ service cloud.firestore {
     // これから書き込むドキュメントの lineId が自分のものか。
     function writingAsSelf() {
       return isSignedIn() && request.resource.data.lineId == myLineId();
+    }
+    // グループ（LINEグループ／アプリ内グループ）に属するドキュメントか。
+    function isGroupDoc() {
+      return resource.data.lineGroupId != null || resource.data.groupId != null;
+    }
+    // Gmail 自動取込がシステムユーザーとして登録した支出か。
+    // bot/src/gmail/handler.ts の GMAIL_SYSTEM_LINE_ID と一致させること。
+    function isGmailSystemDoc() {
+      return resource.data.lineId == 'gmail-auto-system';
+    }
+    // 所有者の付け替えを伴わない更新か（lineId を書き換えさせない）。
+    function keepsOwner() {
+      return request.resource.data.lineId == resource.data.lineId;
     }
 
     // ---- expenses -----------------------------------------------------------
@@ -48,32 +68,43 @@ service cloud.firestore {
       //   決定的なドキュメントパスが存在しない。Firestore ルールは他コレクションへの
       //   「クエリ」ができず exists()/get() は決定的パスしか辿れないため、
       //   「呼び出し元が当該グループのメンバーか」をルール内で厳密に検証できない。
-      //   よって現状はグループ支出の read を isSignedIn() まで緩めている
-      //   （＝サインイン済みの任意ユーザーが任意のグループ支出を読める余地が残る）。
+      //   よって現状はグループ支出の read を isLineUser() まで緩めている
+      //   （＝LINE 本人確認済みの任意ユーザーが任意のグループ支出を読める余地が残る）。
       //   将来 groupMembers を決定的 ID（例: `${groupId}_${lineId}`）へ移行すれば、
       //   exists(/databases/$(database)/documents/groupMembers/$(...)) で厳密化できる。
-      allow read: if ownsDoc()
-                  || (isSignedIn()
-                      && (resource.data.lineGroupId != null || resource.data.groupId != null));
+      allow read: if ownsDoc() || (isLineUser() && isGroupDoc());
 
       // create: サインイン済みで、自分の lineId を持つドキュメントのみ作成可。
       allow create: if writingAsSelf();
 
-      // update: 既存ドキュメントの所有者のみ。所有権の付け替え（lineId 変更）は禁止。
-      allow update: if ownsDoc() && writingAsSelf();
+      // update:
+      //   - 所有者は従来どおり更新可（所有権の付け替えは禁止）。
+      //   - 加えて、グループ支出はサインイン済みなら更新可とする（所有権の付け替えは禁止）。
+      //     Gmail 自動取込の支出は lineId が固定のシステムユーザー
+      //     ('gmail-auto-system') であり、どの実ユーザーの lineId とも一致しない。
+      //     所有者限定のままだと、世帯の支出の大半（取込分）を web から修正できず、
+      //     LINE カードの「修正」導線が機能しない。read が既に isLineUser() まで
+      //     緩んでいるため、update をそれに揃えても新たな露出の種類は増えない。
+      allow update: if (ownsDoc() && writingAsSelf())
+                    || (isLineUser() && isGroupDoc() && keepsOwner());
 
-      // delete: 既存ドキュメントの所有者のみ。
-      allow delete: if ownsDoc();
+      // delete:
+      //   - 所有者は従来どおり削除可。
+      //   - 加えて、グループ支出のうち Gmail 自動取込分のみサインイン済みで削除可。
+      //     誤取込メールを消せるようにするための最小限の緩和で、人が手入力した
+      //     支出は引き続き本人しか削除できない（不可逆な操作の露出を最小化する）。
+      allow delete: if ownsDoc()
+                    || (isLineUser() && isGroupDoc() && isGmailSystemDoc());
     }
 
     // ---- groups -------------------------------------------------------------
     // 共有家計グループ。createdBy に作成者の LINE userId を持つ。
     // 作成・参加・メンバー追加は Bot（Admin SDK）が行い、ルールをバイパスする。
     match /groups/{groupId} {
-      // read: サインイン済み。
+      // read: 検証済み LINE ユーザー。
       // 【限界】メンバーシップを決定的に検証できない（groupMembers が自動生成 ID）ため、
-      //   read はサインイン済みまで緩める（inviteCode 等も読める余地が残る）。
-      allow read: if isSignedIn();
+      //   read は LINE ユーザーであることまでしか絞れない（inviteCode 等も読める余地が残る）。
+      allow read: if isLineUser();
       // create: 作成者を自分に設定する場合のみ。
       allow create: if isSignedIn() && request.resource.data.createdBy == myLineId();
       // update, delete: 作成者本人のみ。
@@ -84,12 +115,12 @@ service cloud.firestore {
     // グループメンバーシップ。lineId フィールドでメンバー本人を表す。
     // メンバー追加・更新は Bot（Admin SDK）が行い、ルールをバイパスする。
     match /groupMembers/{memberId} {
-      // read: サインイン済み。
+      // read: 検証済み LINE ユーザー。
       // 【限界】useGroupMembers は groupId でグループ全員分を読むため、
       //   他メンバー（別 lineId）のドキュメントも返る。よって read を
       //   resource.data.lineId == myLineId() に絞るとクエリ全体が拒否される。
-      //   決定的なメンバーシップ検証ができないため isSignedIn() まで緩める。
-      allow read: if isSignedIn();
+      //   決定的なメンバーシップ検証ができないため LINE ユーザーまでで留める。
+      allow read: if isLineUser();
       // create: 自分の lineId のメンバーシップのみ作成可。
       allow create: if writingAsSelf();
       // update, delete: 自分のメンバーシップのみ。

--- a/storage.rules
+++ b/storage.rules
@@ -14,15 +14,18 @@ rules_version = '2';
 
 service firebase.storage {
   match /b/{bucket}/o {
-    function isSignedIn() {
-      return request.auth != null;
+    // 匿名サインインは公開 API キーだけで誰でも作れるため、request.auth != null は
+    // 実質「誰でも」と同義。LINE 本人確認を経たセッションだけが lineId クレームを
+    // 持つので、そちらを条件にする。
+    function isLineUser() {
+      return request.auth != null && request.auth.token.lineId != null;
     }
 
     match /receipts/{expenseId}/{fileName} {
       // read: サインイン済みのみ（従来の `if true` を廃止）。
-      allow read: if isSignedIn();
+      allow read: if isLineUser();
       // write: サインイン済み、かつ従来のサイズ/コンテンツタイプ制約を維持。
-      allow write: if isSignedIn()
+      allow write: if isLineUser()
                    && request.resource.size < 10 * 1024 * 1024
                    && request.resource.contentType.matches('image/.*');
     }

--- a/test/firestore.rules.test.mjs
+++ b/test/firestore.rules.test.mjs
@@ -37,6 +37,12 @@ await env.withSecurityRulesDisabled(async (ctx) => {
   await setDoc(doc(db, 'expenses/expA'), { lineId: 'A', amount: 100, date: '2026-08-01' });
   await setDoc(doc(db, 'expenses/expB'), { lineId: 'B', amount: 200, date: '2026-08-01' });
   await setDoc(doc(db, 'expenses/expG'), { lineId: 'B', lineGroupId: 'G1', amount: 300, date: '2026-08-01' });
+  // Gmail 自動取込はシステムユーザー名義で登録される（bot の GMAIL_SYSTEM_LINE_ID）
+  await setDoc(doc(db, 'expenses/expGmail'), { lineId: 'gmail-auto-system', lineGroupId: 'G1', amount: 400, date: '2026-08-01' });
+  // グループに属さない Gmail 支出（実データには無いが、緩和がグループ限定であることの確認用）
+  await setDoc(doc(db, 'expenses/expGmailSolo'), { lineId: 'gmail-auto-system', amount: 500, date: '2026-08-01' });
+  await setDoc(doc(db, 'groups/G1'), { createdBy: 'B', inviteCode: 'INV123' });
+  await setDoc(doc(db, 'groupMembers/m1'), { groupId: 'G1', lineId: 'B' });
   await setDoc(doc(db, 'budgetSettings/A'), { monthlyBudget: 1000 });
   await setDoc(doc(db, 'budgetSettings/B'), { monthlyBudget: 2000 });
   await setDoc(doc(db, 'linkTokens/t1'), { lineId: 'A' });
@@ -121,6 +127,45 @@ await test('userLinks: user can read own (uid match)', async () => {
 await test('userLinks: user canNOT read other uid', async () => {
   await assertFails(getDoc(doc(userB, 'userLinks/appuid-A')));
 });
+// ---- グループ支出の書き込み緩和（Gmail 自動取込を web から扱えるようにする） ----
+await test('group expense: signed-in user can UPDATE (not owner)', async () => {
+  await assertSucceeds(updateDoc(doc(userA, 'expenses/expG'), { amount: 301 }));
+});
+await test('group expense: gmail-owned can be UPDATED by signed-in user', async () => {
+  await assertSucceeds(updateDoc(doc(userA, 'expenses/expGmail'), { amount: 401 }));
+});
+await test('group expense: UPDATE canNOT reassign owner', async () => {
+  await assertFails(updateDoc(doc(userA, 'expenses/expGmail'), { lineId: 'A' }));
+});
+await test('non-group expense of others still DENIED for update', async () => {
+  await assertFails(updateDoc(doc(userA, 'expenses/expB'), { amount: 999 }));
+});
+await test('group expense: gmail-owned can be DELETED by signed-in user', async () => {
+  await assertSucceeds(deleteDoc(doc(userA, 'expenses/expGmail')));
+});
+await test('group expense authored by a person canNOT be deleted by others', async () => {
+  await assertFails(deleteDoc(doc(userA, 'expenses/expG')));
+});
+await test('gmail expense OUTSIDE a group canNOT be deleted', async () => {
+  await assertFails(deleteDoc(doc(userA, 'expenses/expGmailSolo')));
+});
+await test('LINE user can read groups / groupMembers', async () => {
+  await assertSucceeds(getDoc(doc(userA, 'groups/G1')));
+  await assertSucceeds(getDoc(doc(userA, 'groupMembers/m1')));
+});
+await test('anonymous user canNOT READ group expense', async () => {
+  await assertFails(getDoc(doc(anon, 'expenses/expG')));
+});
+await test('anonymous user canNOT read groups', async () => {
+  await assertFails(getDoc(doc(anon, 'groups/G1')));
+});
+await test('anonymous user canNOT read groupMembers', async () => {
+  await assertFails(getDoc(doc(anon, 'groupMembers/m1')));
+});
+await test('anonymous user canNOT update group expense', async () => {
+  await assertFails(updateDoc(doc(anon, 'expenses/expG'), { amount: 777 }));
+});
+
 await test('default-deny: unknown collection read DENIED', async () => {
   await assertFails(getDoc(doc(userA, 'userCustomCategories/x')));
 });


### PR DESCRIPTION
## 🎯 背景

「同じ LINE グループの家計簿として成り立っているか」を実データで確認する過程で、#157 のルールに**2つの問題**が見つかった。1つは機能不全、もう1つは**セキュリティホール**。

閲覧自体は成り立っている（1グループ・共有支出 459 件・投稿元3つがすべて正しく見える）が、以下が壊れていた。

## 🐛 問題1: Gmail 取込分（全体の60%）が web から編集・削除できない

Gmail 自動取込の支出は `lineId` が固定のシステムユーザー `'gmail-auto-system'`（`bot/src/gmail/handler.ts:29`）で登録される。#157 の所有者ベースのルールは

```
function ownsDoc() { return isSignedIn() && resource.data.lineId == myLineId(); }
allow update: if ownsDoc() && writingAsSelf();
```

なので、**どの実ユーザーの lineId とも一致せず**、閲覧はできても更新・削除が拒否されていた。

本番データでは **492 件中 296 件（60%）** が該当し、日付は 2026-03-14 〜 現在と現在進行形。LINE カードの「修正」ボタンは `/expenses?edit=<id>` を開くため、**この導線が機能しない**状態だった。

### 対応

- **update**: グループ支出は所有者以外でも更新可にする（所有権の付け替えは引き続き禁止）。read が既に同水準まで緩んでいるため、露出の種類は増えない。
- **delete**: グループ支出のうち **Gmail 取込分のみ**削除可にする。誤取込メールを消せるようにする最小限の緩和で、**人が手入力した支出は引き続き本人のみ削除可**。不可逆な操作の露出を最小化する意図。

## 🔒 問題2: 匿名セッションからグループ支出が読めてしまう（#157 の積み残し）

グループ条項が `isSignedIn()` だけを見ていた。**Firebase の匿名サインインは公開 API キーだけで誰でも作れる**ため、これは実質「誰でも」と同義。第三者がグループ支出・`groups`（`inviteCode` を含む）・`groupMembers`・受領画像を読める状態だった。

#157 のコメントは「匿名ユーザーは lineId クレームを持たないためフェイルセーフに拒否される」としていたが、それが成り立つのは**所有者判定・doc-id 判定のみ**で、`isSignedIn()` だけを見るグループ条項には当てはまらない。

### 対応

検証済み lineId クレームを要求する `isLineUser()` を追加し、グループ条項（`expenses` / `groups` / `groupMembers`）と `storage.rules` の全条件をこれに置き換えた。

```
function isLineUser() {
  return isSignedIn() && request.auth.token.lineId != null;
}
```

## 🔧 変更種別

- [x] 🔒 セキュリティ (Security)
- [x] 🐛 バグ修正 (Bug fix)

## 🧪 テスト

**エミュレータでルールユニットテスト 35 ケース pass**（従来 23 + 追加 12）。

```
35 passed, 0 failed
```

上記2件はいずれも追加したテストで検出・検証している。特に問題2は「匿名ユーザーはグループ支出を更新できない」というテストを書いたところ `Expected request to fail, but it succeeded.` で FAIL し、**テストを書いたこと自体が既存の穴の発見につながった**。

追加した主なケース:

| ケース | 期待 |
|---|---|
| グループ支出を所有者以外の LINE ユーザーが更新 | 許可 |
| Gmail 名義のグループ支出を更新 | 許可 |
| 更新時の所有者付け替え | 拒否 |
| グループ外の他人の支出を更新 | 拒否 |
| Gmail 名義のグループ支出を削除 | 許可 |
| 人が手入力したグループ支出を他人が削除 | 拒否 |
| グループ外の Gmail 支出を削除 | 拒否 |
| 匿名でグループ支出を read / update | 拒否 |
| 匿名で groups / groupMembers を read | 拒否 |
| LINE ユーザーで groups / groupMembers を read | 許可 |

実行手順はテストファイル冒頭に記載（Java 21 以上 + Firestore エミュレータが必要）。

## 📌 残る限界（本PR対象外）

`groupMembers` が自動生成 ID のため、ルール内で「呼び出し元が当該グループのメンバーか」を厳密に検証できない。そのためグループ支出の read/update は「**LINE 本人確認済みの任意ユーザー**」まで（匿名は排除されたが、無関係な LINE ユーザーは残る）。

`groupMembers` を決定的 ID（`${groupId}_${lineId}`）へ移行すれば `exists()` でメンバー限定に厳密化できる。データ移行を伴うため別対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GcXZLvy359vkTHoQUDbx2
