### PR TITLE
feat(bot): groupMembers を決定的ドキュメントIDで書き込む（Phase 1）

### DIFF
--- a/bot/src/firestore.ts
+++ b/bot/src/firestore.ts
@@ -647,16 +647,36 @@ export async function joinGroup(inviteCode: string, lineId: string, displayName:
   }
 }
 
+/**
+ * groupMembers のドキュメントID。
+ *
+ * セキュリティルールから `exists()` でメンバーシップを検証できるよう、
+ * 自動生成IDではなく (groupId, lineId) から決定的に導出する。
+ * ルール側もこの組み立て方に依存するため、変更する場合は firestore.rules と
+ * scripts/migrate-group-members.mjs も併せて更新すること。
+ */
+export function groupMemberDocId(groupId: string, lineId: string): string {
+  return `${groupId}_${lineId}`;
+}
+
 export async function addGroupMember(groupId: string, lineId: string, displayName: string): Promise<void> {
   try {
     const now = Timestamp.now();
-    await getDb().collection('groupMembers').add({
-      groupId,
-      lineId,
-      displayName,
-      joinedAt: now,
-      isActive: true
-    });
+    // 決定的IDなので、同じメンバーの再参加は上書きになり重複ドキュメントが増えない。
+    // merge:true により、既存の joinedAt など保持したいフィールドを壊さない。
+    await getDb()
+      .collection('groupMembers')
+      .doc(groupMemberDocId(groupId, lineId))
+      .set(
+        {
+          groupId,
+          lineId,
+          displayName,
+          joinedAt: now,
+          isActive: true,
+        },
+        { merge: true }
+      );
   } catch (error) {
     console.error('Error adding group member:', error);
     throw error;

--- a/scripts/migrate-group-members.mjs
+++ b/scripts/migrate-group-members.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * groupMembers を決定的ドキュメントID（`${groupId}_${lineId}`）へ移行する。
+ *
+ * 背景:
+ *   groupMembers は `.add()` の自動生成IDで作られていたため、セキュリティルールから
+ *   「呼び出し元が当該グループのメンバーか」を決定的なパスで検証できなかった。
+ *   ID を (groupId, lineId) から導出すれば、ルール内で
+ *   `exists(/databases/$(db)/documents/groupMembers/$(groupId + '_' + myLineId()))`
+ *   によるメンバー限定の判定ができる。
+ *
+ * 実行方法（既定は dry-run。実際に書き換えるには --apply を付ける）:
+ *   ./google-cloud-sdk/bin/gcloud auth print-access-token > /dev/null   # 事前にログイン確認
+ *   node scripts/migrate-group-members.mjs              # dry-run
+ *   node scripts/migrate-group-members.mjs --apply      # 実行
+ *
+ * Firestore REST API をオーナー権限のアクセストークンで叩く（セキュリティルールを
+ * バイパスする）。Admin SDK を使わないのは、この環境では
+ * GOOGLE_APPLICATION_CREDENTIALS の指す鍵ファイルが存在しないため。
+ *
+ * 冪等。既に決定的IDへ移行済みのドキュメントは何もしない。
+ */
+import { execFileSync } from 'node:child_process';
+
+const PROJECT = process.env.FIREBASE_PROJECT_ID || 'line-kakeibo-0410';
+const GCLOUD = process.env.GCLOUD_BIN || './google-cloud-sdk/bin/gcloud';
+const APPLY = process.argv.includes('--apply');
+const BASE = `https://firestore.googleapis.com/v1/projects/${PROJECT}/databases/(default)/documents`;
+
+const token = execFileSync(GCLOUD, ['auth', 'print-access-token'], {
+  encoding: 'utf8',
+}).trim();
+
+const authHeaders = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+async function api(path, init = {}) {
+  const res = await fetch(`${BASE}${path}`, { ...init, headers: authHeaders });
+  if (!res.ok) {
+    throw new Error(`${init.method || 'GET'} ${path} -> HTTP ${res.status} ${await res.text()}`);
+  }
+  return res.status === 204 ? null : res.json();
+}
+
+/** ページングしてコレクション全件を取得する */
+async function listAll(collection) {
+  const out = [];
+  let pageToken = '';
+  do {
+    const q = `?pageSize=300${pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : ''}`;
+    const page = await api(`/${collection}${q}`);
+    out.push(...(page.documents || []));
+    pageToken = page.nextPageToken || '';
+  } while (pageToken);
+  return out;
+}
+
+const docId = (doc) => doc.name.split('/').pop();
+const str = (doc, field) => doc.fields?.[field]?.stringValue ?? null;
+/** ログに個人識別子をそのまま出さない */
+const mask = (s) => (s ? `${s.slice(0, 6)}…${s.slice(-4)}` : '(なし)');
+
+// ---------------------------------------------------------------- 移行本体
+const members = await listAll('groupMembers');
+console.log(`groupMembers: ${members.length} 件`);
+
+const planned = [];
+for (const doc of members) {
+  const id = docId(doc);
+  const groupId = str(doc, 'groupId');
+  const lineId = str(doc, 'lineId');
+  if (!groupId || !lineId) {
+    console.log(`  SKIP  ${mask(id)} — groupId / lineId が欠けている（手動確認が必要）`);
+    continue;
+  }
+  const targetId = `${groupId}_${lineId}`;
+  if (id === targetId) {
+    console.log(`  OK    ${mask(id)} — 移行済み`);
+    continue;
+  }
+  planned.push({ oldId: id, targetId, fields: doc.fields });
+  console.log(`  MOVE  ${mask(id)} -> ${mask(targetId)}`);
+}
+
+if (planned.length === 0) {
+  console.log('\n移行対象はありません。');
+} else if (!APPLY) {
+  console.log(`\n[dry-run] ${planned.length} 件が移行対象です。--apply を付けると実行します。`);
+} else {
+  for (const { oldId, targetId, fields } of planned) {
+    // 新IDで作成（フィールドはそのままコピー。joinedAt 等のタイムスタンプを作り直さない）
+    await api(`/groupMembers/${encodeURIComponent(targetId)}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ fields }),
+    });
+    // 新ドキュメントの生成を確認してから旧ドキュメントを消す
+    await api(`/groupMembers/${encodeURIComponent(targetId)}`);
+    await api(`/groupMembers/${encodeURIComponent(oldId)}`, { method: 'DELETE' });
+    console.log(`  DONE  ${mask(oldId)} -> ${mask(targetId)}`);
+  }
+}
+
+// ------------------------------------------------------- 移行後の検証（Phase 2 のゲート）
+console.log('\n=== 検証 ===');
+const after = await listAll('groupMembers');
+
+// 1) 全ドキュメントが決定的IDになっているか
+const stray = after.filter((d) => docId(d) !== `${str(d, 'groupId')}_${str(d, 'lineId')}`);
+console.log(`[1] 決定的IDでないドキュメント: ${stray.length} 件` + (stray.length ? ' ← 要対応' : ' ✓'));
+
+// 2) 同一 (groupId, lineId) の重複が無いか（重複はメンバー一覧の二重表示になる）
+const seen = new Map();
+for (const d of after) {
+  const key = `${str(d, 'groupId')}_${str(d, 'lineId')}`;
+  seen.set(key, (seen.get(key) || 0) + 1);
+}
+const dupes = [...seen.entries()].filter(([, n]) => n > 1);
+console.log(`[2] 重複メンバー: ${dupes.length} 件` + (dupes.length ? ' ← 要対応' : ' ✓'));
+
+// 3) グループ支出を持つ全 LINE ユーザーがメンバードキュメントを持つか
+//    これが満たされないまま Phase 2（ルール厳格化）を出すと、その利用者は
+//    グループ家計簿が見えなくなる。Phase 2 の前提条件。
+const expenses = await (async () => {
+  const res = await fetch(`${BASE}:runQuery`, {
+    method: 'POST',
+    headers: authHeaders,
+    body: JSON.stringify({
+      structuredQuery: {
+        from: [{ collectionId: 'expenses' }],
+        select: { fields: [{ fieldPath: 'lineId' }, { fieldPath: 'groupId' }] },
+        limit: 5000,
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`runQuery -> HTTP ${res.status}`);
+  return (await res.json()).filter((r) => r.document).map((r) => r.document);
+})();
+
+const memberIds = new Set(after.map(docId));
+const needed = new Map(); // `${groupId}_${lineId}` -> 件数
+for (const e of expenses) {
+  const groupId = str(e, 'groupId');
+  const lineId = str(e, 'lineId');
+  // LINE 実ユーザーのみ対象。Gmail 取込のシステムユーザーはメンバーではない。
+  if (!groupId || !lineId || !lineId.startsWith('U')) continue;
+  const key = `${groupId}_${lineId}`;
+  needed.set(key, (needed.get(key) || 0) + 1);
+}
+const missing = [...needed.keys()].filter((k) => !memberIds.has(k));
+console.log(
+  `[3] グループ支出を持つ LINE ユーザー: ${needed.size} 名 / メンバー未登録: ${missing.length} 名` +
+    (missing.length ? ' ← Phase 2 を出す前に要対応' : ' ✓')
+);
+for (const k of missing) console.log(`      未登録: ${mask(k)}`);
+
+const ok = stray.length === 0 && dupes.length === 0 && missing.length === 0;
+console.log(`\n判定: ${ok ? '✓ Phase 2（ルール厳格化）へ進めます' : '✗ 未解決の項目があります'}`);
+process.exit(ok ? 0 : 1);

--- a/scripts/migrate-group-members.mjs
+++ b/scripts/migrate-group-members.mjs
@@ -41,12 +41,18 @@ async function api(path, init = {}) {
   return res.status === 204 ? null : res.json();
 }
 
-/** ページングしてコレクション全件を取得する */
-async function listAll(collection) {
+/**
+ * ページングしてコレクション全件を取得する。
+ * selectFields を渡すと、そのフィールドだけを取得する（不要な個人データを読まない）。
+ */
+async function listAll(collection, selectFields) {
   const out = [];
   let pageToken = '';
+  const mask = (selectFields || [])
+    .map((f) => `&mask.fieldPaths=${encodeURIComponent(f.fieldPath)}`)
+    .join('');
   do {
-    const q = `?pageSize=300${pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : ''}`;
+    const q = `?pageSize=300${mask}${pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : ''}`;
     const page = await api(`/${collection}${q}`);
     out.push(...(page.documents || []));
     pageToken = page.nextPageToken || '';
@@ -86,14 +92,22 @@ if (planned.length === 0) {
 } else if (!APPLY) {
   console.log(`\n[dry-run] ${planned.length} 件が移行対象です。--apply を付けると実行します。`);
 } else {
+  const existingIds = new Set(members.map(docId));
   for (const { oldId, targetId, fields } of planned) {
-    // 新IDで作成（フィールドはそのままコピー。joinedAt 等のタイムスタンプを作り直さない）
-    await api(`/groupMembers/${encodeURIComponent(targetId)}`, {
-      method: 'PATCH',
-      body: JSON.stringify({ fields }),
-    });
-    // 新ドキュメントの生成を確認してから旧ドキュメントを消す
-    await api(`/groupMembers/${encodeURIComponent(targetId)}`);
+    if (existingIds.has(targetId)) {
+      // 前回の実行が「新ID作成後・旧ID削除前」で中断した場合、移行先には既に
+      // 正しい（場合によっては更新済みの）状態がある。ここで旧IDの内容を書き戻すと
+      // displayName / isActive などを巻き戻してしまうため、上書きせず旧IDだけ消す。
+      console.log(`  KEEP  ${mask(targetId)} は既に存在するため上書きしない`);
+    } else {
+      // 新IDで作成（フィールドはそのままコピー。joinedAt 等のタイムスタンプを作り直さない）
+      await api(`/groupMembers/${encodeURIComponent(targetId)}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ fields }),
+      });
+      // 新ドキュメントの生成を確認してから旧ドキュメントを消す
+      await api(`/groupMembers/${encodeURIComponent(targetId)}`);
+    }
     await api(`/groupMembers/${encodeURIComponent(oldId)}`, { method: 'DELETE' });
     console.log(`  DONE  ${mask(oldId)} -> ${mask(targetId)}`);
   }
@@ -116,26 +130,21 @@ for (const d of after) {
 const dupes = [...seen.entries()].filter(([, n]) => n > 1);
 console.log(`[2] 重複メンバー: ${dupes.length} 件` + (dupes.length ? ' ← 要対応' : ' ✓'));
 
-// 3) グループ支出を持つ全 LINE ユーザーがメンバードキュメントを持つか
+// 3) グループ支出を持つ全 LINE ユーザーが「有効な」メンバードキュメントを持つか
 //    これが満たされないまま Phase 2（ルール厳格化）を出すと、その利用者は
 //    グループ家計簿が見えなくなる。Phase 2 の前提条件。
-const expenses = await (async () => {
-  const res = await fetch(`${BASE}:runQuery`, {
-    method: 'POST',
-    headers: authHeaders,
-    body: JSON.stringify({
-      structuredQuery: {
-        from: [{ collectionId: 'expenses' }],
-        select: { fields: [{ fieldPath: 'lineId' }, { fieldPath: 'groupId' }] },
-        limit: 5000,
-      },
-    }),
-  });
-  if (!res.ok) throw new Error(`runQuery -> HTTP ${res.status}`);
-  return (await res.json()).filter((r) => r.document).map((r) => r.document);
-})();
+// 件数上限を切ると、上限を超えた分に未登録メンバーが紛れていても
+// 「安全」と報告してしまう。ページングして全件を見る。
+const expenses = await listAll('expenses', [
+  { fieldPath: 'lineId' },
+  { fieldPath: 'groupId' },
+]);
 
-const memberIds = new Set(after.map(docId));
+// Phase 2 のルールは isActive == true のメンバーシップだけを有効とみなす。
+// ここで無効なものまで「登録済み」と数えると、脱退扱いの利用者がゲートを
+// 通過したのちルール側で拒否され、グループ家計簿が見えなくなる。
+const bool = (doc, field) => doc.fields?.[field]?.booleanValue === true;
+const memberIds = new Set(after.filter((d) => bool(d, 'isActive')).map(docId));
 const needed = new Map(); // `${groupId}_${lineId}` -> 件数
 for (const e of expenses) {
   const groupId = str(e, 'groupId');
@@ -147,7 +156,7 @@ for (const e of expenses) {
 }
 const missing = [...needed.keys()].filter((k) => !memberIds.has(k));
 console.log(
-  `[3] グループ支出を持つ LINE ユーザー: ${needed.size} 名 / メンバー未登録: ${missing.length} 名` +
+  `[3] グループ支出を持つ LINE ユーザー: ${needed.size} 名 / 有効なメンバー登録なし: ${missing.length} 名` +
     (missing.length ? ' ← Phase 2 を出す前に要対応' : ' ✓')
 );
 for (const k of missing) console.log(`      未登録: ${mask(k)}`);


### PR DESCRIPTION
## 🎯 目的

#157 / #162 に「既知の限界」として残していた、**グループ支出の read/update が「LINE 本人確認済みの任意ユーザー」まで（そのグループのメンバーに限定できない）** という問題を解消するための第1段階。

`groupMembers` が `.add()` の自動生成IDで作られているため、ルールから決定的なパスを組み立てられず、`exists()` によるメンバー判定ができなかった。ドキュメントIDを `(groupId, lineId)` 由来の決定的IDに変えることで、Phase 2 で以下が書けるようになる。

```
exists(/databases/$(database)/documents/groupMembers/$(resource.data.groupId + '_' + myLineId()))
```

## ⚠️ 本PRはルールを変更しない

アクセス条件は一切変わらない。順序を守らないと利用者がロックアウトされるため、#156 → #157 と同じく段階を分けている。

| 段階 | 内容 | アクセスへの影響 |
|---|---|---|
| **Phase 1（本PR）** | bot が決定的IDで書き込む + 移行スクリプト | なし |
| 移行実行 | 既存ドキュメントを新IDへ移し旧IDを削除 | なし |
| Phase 2 | ルールをメンバーシップ判定に厳格化 | ここで初めて変わる |

## 📋 変更内容

### `bot/src/firestore.ts`

- `groupMemberDocId(groupId, lineId)` を追加（`${groupId}_${lineId}`）。ルールと移行スクリプトがこの組み立て方に依存するため、変更時の同期先をコメントに明記した。
- `addGroupMember` を `.add()` → `.doc(id).set(..., { merge: true })` に変更。決定的IDになるため**再参加が上書きになり、重複ドキュメントが増えない**（従来は `.add()` なので、参加済みチェックをすり抜けると重複しえた）。
- 既存の「参加済みか」を確認するクエリ（`where('groupId').where('lineId')`）は**そのまま残す**。決定的IDのドキュメントも同じフィールドを持つため引き続き機能し、差分を最小に保てる。

### `scripts/migrate-group-members.mjs`（新規）

既定は **dry-run**、`--apply` で実行。冪等。Firestore REST API をオーナー権限のアクセストークンで叩く（この環境では `GOOGLE_APPLICATION_CREDENTIALS` の指す鍵ファイルが存在しないため Admin SDK ではなく REST）。

- フィールドは**そのままコピー**（`joinedAt` 等のタイムスタンプを作り直さない）
- **新ドキュメントの生成を確認してから**旧ドキュメントを削除
- ログに個人識別子をそのまま出さない（マスク表示）

**Phase 2 の前提条件を検証する**のがこのスクリプトのもう一つの役割:

| # | 検証内容 | 満たされないと |
|---|---|---|
| 1 | 全ドキュメントが決定的IDか | ルールの `exists()` が引けない |
| 2 | 同一 `(groupId, lineId)` の重複が無いか | メンバー一覧が二重表示になる |
| 3 | グループ支出を持つ全 LINE ユーザーがメンバードキュメントを持つか | **その利用者がグループ家計簿を見られなくなる** |

3つすべてが ✓ になったときだけ exit 0 を返す。Phase 2 はこれをゲートにする。

## 🧪 テスト

- [x] `npm -w bot run build`（tsc）成功
- [x] `npm -w bot run lint` 通過
- [x] `node --check scripts/migrate-group-members.mjs` 構文チェック通過
- [x] **本番に対して dry-run を実行**し、移行対象2件の検出と検証3項目の判定が期待どおりであることを確認（移行前なので [1] と [3] が「要対応」と出るのが正しい挙動）

```
groupMembers: 2 件
  MOVE  ○○ -> ○○
  MOVE  ○○ -> ○○

[dry-run] 2 件が移行対象です。--apply を付けると実行します。

=== 検証 ===
[1] 決定的IDでないドキュメント: 2 件 ← 要対応
[2] 重複メンバー: 0 件 ✓
[3] グループ支出を持つ LINE ユーザー: 2 名 / メンバー未登録: 2 名 ← Phase 2 を出す前に要対応

判定: ✗ 未解決の項目があります
```

## 📌 設計の根拠（実データで確認済み）

- 支出 492 件のうち **480 件が `groupId`**（= `groups` のドキュメントID）を持ち、`groupMembers.groupId` と一致する。`lineGroupId` を持つ 459 件は**すべて `groupId` も持つ**ため、キーは `groupId` に統一できる。
- web は `groupMembers` / `groups` に**書き込まない**（読み取りのみ）。したがって Phase 2 でクライアント書き込みを禁止しても機能影響はない。
- ルールの `get()`/`exists()` は1評価あたり **10回**が上限だが、同一パスはキャッシュされ回数に数えられない。全支出が同じ `groupId`・同じ利用者を参照するためパスは1種類で、大量件数のクエリでも実質1回に収まる。

## 🚀 次の手順

1. 本PRをマージ
2. `node scripts/migrate-group-members.mjs --apply` を実行（**本番ドキュメントを削除するため実行前に確認を取る**）
3. 検証3項目がすべて ✓ になったことを確認
4. Phase 2（ルール厳格化）の PR を作成。エミュレータでのルールユニットテストを追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GcXZLvy359vkTHoQUDbx2
