### PR TITLE
feat(security): グループデータをメンバー限定に厳格化（Phase 2）

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -36,24 +36,52 @@ service cloud.firestore {
     }
     // 既存ドキュメントの所有者か（lineId フィールド一致）。
     function ownsDoc() {
-      return isSignedIn() && resource.data.lineId == myLineId();
+      return isSignedIn() && resource.data.get('lineId', null) == myLineId();
     }
     // これから書き込むドキュメントの lineId が自分のものか。
     function writingAsSelf() {
       return isSignedIn() && request.resource.data.lineId == myLineId();
     }
-    // グループ（LINEグループ／アプリ内グループ）に属するドキュメントか。
-    function isGroupDoc() {
-      return resource.data.lineGroupId != null || resource.data.groupId != null;
+    // 支出ドキュメントが属するアプリ内グループのID（無ければ null）。
+    // 直接 resource.data.groupId を参照すると、フィールドを持たないドキュメントで
+    // 評価エラーになるため get(key, default) を使う。
+    function docGroupId() {
+      return resource.data.get('groupId', null);
+    }
+    // そのグループの有効なメンバーか。
+    //
+    // groupMembers のドキュメントIDは bot/src/firestore.ts の groupMemberDocId() と
+    // 同じ規則（`${groupId}_${lineId}`）で組み立てる。変更する場合は
+    // scripts/migrate-group-members.mjs も併せて更新すること。
+    //
+    // exists() と get() は同一パスならキャッシュされ、1評価あたり10回という
+    // ドキュメントアクセス上限にも1回としてしか数えられない。支出一覧のように
+    // 数百件を返すクエリでも、参照先は「自分の当該グループのメンバー文書」1つに
+    // 収まるため上限にも課金にも影響しない。
+    //
+    // 【重要】list（クエリ）はドキュメントを1件ずつ評価するのではなく、
+    // 「クエリの制約からルールを満たすと証明できるか」で判定される。したがって
+    // ルールが参照するフィールドを、クエリが等値で制約していなければ拒否される。
+    // グループ支出は必ず where('groupId','==',…) で引くこと
+    // （where('lineGroupId','==',…) では groupId を証明できず拒否される）。
+    function isMemberOf(groupId) {
+      return isLineUser()
+             && groupId != null
+             && exists(/databases/$(database)/documents/groupMembers/$(groupId + '_' + myLineId()))
+             && get(/databases/$(database)/documents/groupMembers/$(groupId + '_' + myLineId())).data.get('isActive', false) == true;
+    }
+    // 対象ドキュメントのグループのメンバーか。
+    function isMemberOfDocGroup() {
+      return isMemberOf(docGroupId());
     }
     // Gmail 自動取込がシステムユーザーとして登録した支出か。
     // bot/src/gmail/handler.ts の GMAIL_SYSTEM_LINE_ID と一致させること。
     function isGmailSystemDoc() {
-      return resource.data.lineId == 'gmail-auto-system';
+      return resource.data.get('lineId', null) == 'gmail-auto-system';
     }
     // 所有者の付け替えを伴わない更新か（lineId を書き換えさせない）。
     function keepsOwner() {
-      return request.resource.data.lineId == resource.data.lineId;
+      return request.resource.data.get('lineId', null) == resource.data.get('lineId', null);
     }
 
     // ---- expenses -----------------------------------------------------------
@@ -62,69 +90,76 @@ service cloud.firestore {
     match /expenses/{expenseId} {
       // read:
       //   - 所有者（resource.data.lineId == myLineId()）は常に読める。
-      //   - グループ支出（lineGroupId もしくは groupId を持つ）はサインイン済みなら読める。
-      // 【限界】グループのメンバーシップは groupMembers コレクションで表現されるが、
-      //   groupMembers ドキュメントは .add() による自動生成 ID で作られており、
-      //   決定的なドキュメントパスが存在しない。Firestore ルールは他コレクションへの
-      //   「クエリ」ができず exists()/get() は決定的パスしか辿れないため、
-      //   「呼び出し元が当該グループのメンバーか」をルール内で厳密に検証できない。
-      //   よって現状はグループ支出の read を isLineUser() まで緩めている
-      //   （＝LINE 本人確認済みの任意ユーザーが任意のグループ支出を読める余地が残る）。
-      //   将来 groupMembers を決定的 ID（例: `${groupId}_${lineId}`）へ移行すれば、
-      //   exists(/databases/$(database)/documents/groupMembers/$(...)) で厳密化できる。
-      allow read: if ownsDoc() || (isLineUser() && isGroupDoc());
+      //   - グループ支出は、そのグループの有効なメンバーだけが読める。
+      // groupMembers を決定的ID（`${groupId}_${lineId}`）へ移行したことで、
+      // 「呼び出し元が当該グループのメンバーか」を exists()/get() で検証できるように
+      // なった。従来の「LINE 本人確認済みなら誰でも読める」状態はここで解消される。
+      //
+      // 【前提】グループ支出には groupId が付いている必要がある。bot の登録経路は
+      //   いずれも groupId と lineGroupId を同時に設定するが、groupId は
+      //   getUserGroups()（= groupMembers 検索）由来のため、メンバー未登録の利用者が
+      //   LINEグループで登録すると groupId を持たない支出になりうる。その支出は
+      //   所有者本人しか読めない。招待コードでの参加を経てメンバーになることが前提。
+      allow read: if ownsDoc() || isMemberOfDocGroup();
 
       // create: サインイン済みで、自分の lineId を持つドキュメントのみ作成可。
       allow create: if writingAsSelf();
 
       // update:
       //   - 所有者は従来どおり更新可（所有権の付け替えは禁止）。
-      //   - 加えて、グループ支出はサインイン済みなら更新可とする（所有権の付け替えは禁止）。
+      //   - 加えて、グループ支出はそのグループのメンバーが更新可（所有権の付け替えは禁止）。
       //     Gmail 自動取込の支出は lineId が固定のシステムユーザー
       //     ('gmail-auto-system') であり、どの実ユーザーの lineId とも一致しない。
       //     所有者限定のままだと、世帯の支出の大半（取込分）を web から修正できず、
-      //     LINE カードの「修正」導線が機能しない。read が既に isLineUser() まで
-      //     緩んでいるため、update をそれに揃えても新たな露出の種類は増えない。
+      //     LINE カードの「修正」導線が機能しない。
       allow update: if (ownsDoc() && writingAsSelf())
-                    || (isLineUser() && isGroupDoc() && keepsOwner());
+                    || (isMemberOfDocGroup() && keepsOwner());
 
       // delete:
       //   - 所有者は従来どおり削除可。
-      //   - 加えて、グループ支出のうち Gmail 自動取込分のみサインイン済みで削除可。
+      //   - 加えて、グループ支出のうち Gmail 自動取込分のみメンバーが削除可。
       //     誤取込メールを消せるようにするための最小限の緩和で、人が手入力した
       //     支出は引き続き本人しか削除できない（不可逆な操作の露出を最小化する）。
       allow delete: if ownsDoc()
-                    || (isLineUser() && isGroupDoc() && isGmailSystemDoc());
+                    || (isMemberOfDocGroup() && isGmailSystemDoc());
     }
 
     // ---- groups -------------------------------------------------------------
-    // 共有家計グループ。createdBy に作成者の LINE userId を持つ。
-    // 作成・参加・メンバー追加は Bot（Admin SDK）が行い、ルールをバイパスする。
+    // 共有家計グループ。createdBy に作成者の LINE userId、inviteCode に参加用コードを持つ。
+    // 作成・参加・メンバー追加はすべて Bot（Admin SDK）が行い、ルールをバイパスする。
     match /groups/{groupId} {
-      // read: 検証済み LINE ユーザー。
-      // 【限界】メンバーシップを決定的に検証できない（groupMembers が自動生成 ID）ため、
-      //   read は LINE ユーザーであることまでしか絞れない（inviteCode 等も読める余地が残る）。
-      allow read: if isLineUser();
-      // create: 作成者を自分に設定する場合のみ。
-      allow create: if isSignedIn() && request.resource.data.createdBy == myLineId();
-      // update, delete: 作成者本人のみ。
-      allow update, delete: if isSignedIn() && resource.data.createdBy == myLineId();
+      // read: そのグループのメンバーのみ。inviteCode を含むため、非メンバーには見せない。
+      //
+      // 判定にパスのワイルドカード {groupId} を使うため、これは単一ドキュメント取得
+      // （getDoc）専用の条件になる。list はクエリ制約からの証明が必要で、
+      // ドキュメントIDはクエリ制約に現れないため必ず拒否される。web は所属を
+      // groupMembers から解決して getDoc するのでこれで足りる。
+      allow read: if isMemberOf(groupId);
+
+      // write: クライアントからは全面禁止（Admin SDK はバイパスする）。
+      // web はグループを読み取るだけで作成・更新しない。createdBy を自分にすれば
+      // 作成できる従来の条件は、メンバーシップが権限判定に使われる今となっては
+      // 「自分が作成者のグループを勝手に生やせる」入口になるため塞ぐ。
+      allow write: if false;
     }
 
     // ---- groupMembers -------------------------------------------------------
-    // グループメンバーシップ。lineId フィールドでメンバー本人を表す。
-    // メンバー追加・更新は Bot（Admin SDK）が行い、ルールをバイパスする。
+    // グループメンバーシップ。ドキュメントIDは `${groupId}_${lineId}`（決定的）。
+    // 追加・更新はすべて Bot（Admin SDK）が行い、ルールをバイパスする。
     match /groupMembers/{memberId} {
-      // read: 検証済み LINE ユーザー。
-      // 【限界】useGroupMembers は groupId でグループ全員分を読むため、
-      //   他メンバー（別 lineId）のドキュメントも返る。よって read を
-      //   resource.data.lineId == myLineId() に絞るとクエリ全体が拒否される。
-      //   決定的なメンバーシップ検証ができないため LINE ユーザーまでで留める。
-      allow read: if isLineUser();
-      // create: 自分の lineId のメンバーシップのみ作成可。
-      allow create: if writingAsSelf();
-      // update, delete: 自分のメンバーシップのみ。
-      allow update, delete: if ownsDoc();
+      // read:
+      //   - 自分のメンバーシップ（useGroupMembers 相当の where('lineId','==',自分)）。
+      //   - 同じグループのメンバーであれば他メンバーの行も読める
+      //     （メンバー一覧の where('groupId','==',…) がこれに当たる）。
+      allow read: if isLineUser()
+                  && (resource.data.get('lineId', null) == myLineId()
+                      || isMemberOf(resource.data.get('groupId', null)));
+
+      // write: クライアントからは全面禁止（Admin SDK はバイパスする）。
+      // メンバーシップが権限判定の根拠になったため、自己登録を許すと
+      // 「任意のグループのメンバー文書を自分で作る → そのグループの家計簿を読む」
+      // という権限昇格が成立してしまう。web は groupMembers に書き込まない。
+      allow write: if false;
     }
 
     // ---- userSettings / budgetSettings / dateRangeSettings ------------------
@@ -141,9 +176,15 @@ service cloud.firestore {
     }
 
     // ---- userLinks ----------------------------------------------------------
-    // appUid → lineId のリンク。ドキュメント ID = appUid。本人のみ。
+    // appUid → lineId のリンク。ドキュメント ID = appUid。
+    // read: 本人の appUid のドキュメントのみ。
+    // write: クライアントからは禁止（Admin SDK はバイパスする）。web は書き込まない。
+    //   bot は lineId から appUid を引くのに lineIds の array-contains で検索するため、
+    //   クライアントが任意の lineIds を持つドキュメントを作れると、他人の lineId に
+    //   対する appUid 解決を汚染できてしまう。
     match /userLinks/{uid} {
-      allow read, write: if isSignedIn() && request.auth.uid == uid;
+      allow read: if isSignedIn() && request.auth.uid == uid;
+      allow write: if false;
     }
 
     // ---- linkTokens ---------------------------------------------------------

--- a/test/firestore.rules.test.mjs
+++ b/test/firestore.rules.test.mjs
@@ -1,11 +1,14 @@
 // Firestore セキュリティルールのユニットテスト（参考・任意実行）。
 // テスト用ツール（firebase-tools / @firebase/rules-unit-testing）は依存肥大化・
 // 監査影響を避けるため package.json には含めていない。実行する場合はアドホックに:
-//   npm i -D @firebase/rules-unit-testing firebase-tools
-//   npx firebase emulators:exec --only firestore "node test/firestore.rules.test.mjs"
-// （Java + Firestore エミュレータが必要。リポジトリ直下の firestore.rules を読み込んで検証する）
-// 本ルールはこのテスト23ケース（未認証拒否 / 他人の lineId 拒否 / lineId 不一致 create 拒否 等）
-// が全て pass することを確認済み。
+//   npm i --no-save @firebase/rules-unit-testing firebase-tools
+//   npx firebase emulators:exec --only firestore --project demo-kakeibo "node test/firestore.rules.test.mjs"
+// （Java 21 以上 + Firestore エミュレータが必要。リポジトリ直下の firestore.rules を読み込んで検証する）
+//
+// シードは本番のデータ形状に合わせている:
+//   - グループ支出は groupId（groups のドキュメントID）と lineGroupId を両方持つ
+//   - Gmail 自動取込は lineId が固定のシステムユーザー 'gmail-auto-system'
+//   - groupMembers のドキュメントIDは `${groupId}_${lineId}`（決定的）
 import {
   initializeTestEnvironment,
   assertFails,
@@ -34,15 +37,32 @@ const env = await initializeTestEnvironment({
 // ルールを無効化してシードデータを投入。
 await env.withSecurityRulesDisabled(async (ctx) => {
   const db = ctx.firestore();
+  const group = { groupId: 'G1', lineGroupId: 'L1' };
+
+  // 個人支出
   await setDoc(doc(db, 'expenses/expA'), { lineId: 'A', amount: 100, date: '2026-08-01' });
   await setDoc(doc(db, 'expenses/expB'), { lineId: 'B', amount: 200, date: '2026-08-01' });
-  await setDoc(doc(db, 'expenses/expG'), { lineId: 'B', lineGroupId: 'G1', amount: 300, date: '2026-08-01' });
-  // Gmail 自動取込はシステムユーザー名義で登録される（bot の GMAIL_SYSTEM_LINE_ID）
-  await setDoc(doc(db, 'expenses/expGmail'), { lineId: 'gmail-auto-system', lineGroupId: 'G1', amount: 400, date: '2026-08-01' });
-  // グループに属さない Gmail 支出（実データには無いが、緩和がグループ限定であることの確認用）
+  await setDoc(doc(db, 'expenses/expADel'), { lineId: 'A', amount: 150, date: '2026-08-01' });
+  // グループ支出（人が登録したもの）
+  await setDoc(doc(db, 'expenses/expG'), { lineId: 'B', ...group, amount: 300, date: '2026-08-01' });
+  // グループ支出（Gmail 自動取込）
+  await setDoc(doc(db, 'expenses/expGmail'), { lineId: 'gmail-auto-system', ...group, amount: 400, date: '2026-08-01' });
+  await setDoc(doc(db, 'expenses/expGmailDel'), { lineId: 'gmail-auto-system', ...group, amount: 450, date: '2026-08-01' });
+  // グループに属さない Gmail 支出（緩和がグループ限定であることの確認用）
   await setDoc(doc(db, 'expenses/expGmailSolo'), { lineId: 'gmail-auto-system', amount: 500, date: '2026-08-01' });
-  await setDoc(doc(db, 'groups/G1'), { createdBy: 'B', inviteCode: 'INV123' });
-  await setDoc(doc(db, 'groupMembers/m1'), { groupId: 'G1', lineId: 'B' });
+  // groupId を持たず lineGroupId だけを持つ支出。
+  // 本番データには存在しないが、メンバー未登録の利用者が LINE グループで登録すると
+  // 生まれうる形。メンバーであっても読めないこと（= 所有者限定になること）を固定する。
+  await setDoc(doc(db, 'expenses/expLegacy'), { lineId: 'B', lineGroupId: 'L1', amount: 600, date: '2026-08-01' });
+
+  await setDoc(doc(db, 'groups/G1'), { createdBy: 'B', inviteCode: 'INV123', lineGroupId: 'L1' });
+
+  // 決定的ID: `${groupId}_${lineId}`
+  await setDoc(doc(db, 'groupMembers/G1_A'), { groupId: 'G1', lineId: 'A', displayName: 'A', isActive: true });
+  await setDoc(doc(db, 'groupMembers/G1_B'), { groupId: 'G1', lineId: 'B', displayName: 'B', isActive: true });
+  // 脱退済み（将来 isActive:false を使うようになったときのため）
+  await setDoc(doc(db, 'groupMembers/G1_D'), { groupId: 'G1', lineId: 'D', displayName: 'D', isActive: false });
+
   await setDoc(doc(db, 'budgetSettings/A'), { monthlyBudget: 1000 });
   await setDoc(doc(db, 'budgetSettings/B'), { monthlyBudget: 2000 });
   await setDoc(doc(db, 'linkTokens/t1'), { lineId: 'A' });
@@ -50,123 +70,191 @@ await env.withSecurityRulesDisabled(async (ctx) => {
 });
 
 const unauth = env.unauthenticatedContext().firestore();
-// サインイン済み（lineId カスタムクレームあり）。
-const userA = env.authenticatedContext('appuid-A', { lineId: 'A' }).firestore();
-const userB = env.authenticatedContext('appuid-B', { lineId: 'B' }).firestore();
+// サインイン済み（lineId カスタムクレームあり）＝ LINE 本人確認済み。
+const userA = env.authenticatedContext('appuid-A', { lineId: 'A' }).firestore(); // G1 のメンバー
+const userB = env.authenticatedContext('appuid-B', { lineId: 'B' }).firestore(); // G1 のメンバー
+const userC = env.authenticatedContext('appuid-C', { lineId: 'C' }).firestore(); // LINE ユーザーだがメンバーではない
+const userD = env.authenticatedContext('appuid-D', { lineId: 'D' }).firestore(); // isActive:false のメンバー
 // 匿名フォールバック: サインイン済みだが lineId クレームなし。
 const anon = env.authenticatedContext('anon-uid', {}).firestore();
 
 console.log('Firestore rules tests:');
 
-// --- 契約で必須の3ケース -------------------------------------------------
-await test('(a) unauthenticated read of expenses is DENIED', async () => {
+// --- 認証の基本 -----------------------------------------------------------
+await test('未認証は支出を読めない', async () => {
   await assertFails(getDoc(doc(unauth, 'expenses/expA')));
 });
-await test('(b) userA (lineId=A) can read own expense', async () => {
+await test('匿名（lineId クレームなし）は個人支出を読めない', async () => {
+  await assertFails(getDoc(doc(anon, 'expenses/expA')));
+});
+await test('本人は自分の支出を読める', async () => {
   await assertSucceeds(getDoc(doc(userA, 'expenses/expA')));
 });
-await test('(b) userA canNOT read userB expense (lineId=B)', async () => {
+await test('他人の個人支出は読めない', async () => {
   await assertFails(getDoc(doc(userA, 'expenses/expB')));
 });
-await test('(c) create with mismatched lineId is DENIED', async () => {
+
+// --- 作成 -----------------------------------------------------------------
+await test('自分の lineId なら作成できる', async () => {
+  await assertSucceeds(setDoc(doc(userA, 'expenses/newA'), { lineId: 'A', amount: 5, date: '2026-08-02' }));
+});
+await test('他人の lineId では作成できない', async () => {
   await assertFails(setDoc(doc(userA, 'expenses/newX'), { lineId: 'B', amount: 5, date: '2026-08-02' }));
 });
 
-// --- 追加ケース ----------------------------------------------------------
-await test('create with own lineId is ALLOWED', async () => {
-  await assertSucceeds(setDoc(doc(userA, 'expenses/newA'), { lineId: 'A', amount: 5, date: '2026-08-02' }));
-});
-await test('anonymous (no lineId claim) canNOT read a personal expense', async () => {
-  await assertFails(getDoc(doc(anon, 'expenses/expA')));
-});
-await test('group expense readable by signed-in non-owner (documented limitation)', async () => {
+// --- グループ支出の read: メンバー限定 -------------------------------------
+await test('メンバーはグループ支出を読める', async () => {
   await assertSucceeds(getDoc(doc(userA, 'expenses/expG')));
 });
-await test('owner can update own expense', async () => {
-  await assertSucceeds(updateDoc(doc(userA, 'expenses/expA'), { amount: 111 }));
+await test('メンバーは Gmail 取込のグループ支出を読める', async () => {
+  await assertSucceeds(getDoc(doc(userA, 'expenses/expGmail')));
 });
-await test('non-owner canNOT update expense', async () => {
-  await assertFails(updateDoc(doc(userA, 'expenses/expB'), { amount: 999 }));
+await test('★ 非メンバーの LINE ユーザーはグループ支出を読めない', async () => {
+  await assertFails(getDoc(doc(userC, 'expenses/expG')));
 });
-await test('owner canNOT reassign ownership (change lineId)', async () => {
-  await assertFails(updateDoc(doc(userA, 'expenses/expA'), { lineId: 'B' }));
+await test('★ 脱退済み（isActive:false）メンバーはグループ支出を読めない', async () => {
+  await assertFails(getDoc(doc(userD, 'expenses/expG')));
 });
-await test('owner can delete own expense', async () => {
-  await assertSucceeds(deleteDoc(doc(userA, 'expenses/expA')));
-});
-await test('non-owner canNOT delete expense', async () => {
-  await assertFails(deleteDoc(doc(userA, 'expenses/expB')));
-});
-await test('query where lineId==A succeeds for userA', async () => {
-  await assertSucceeds(getDocs(query(collection(userA, 'expenses'), where('lineId', '==', 'A'))));
-});
-await test('query where lineGroupId==G1 succeeds for signed-in user', async () => {
-  await assertSucceeds(getDocs(query(collection(userA, 'expenses'), where('lineGroupId', '==', 'G1'))));
-});
-await test('budgetSettings: userA reads own (doc id == lineId)', async () => {
-  await assertSucceeds(getDoc(doc(userA, 'budgetSettings/A')));
-});
-await test('budgetSettings: userA canNOT read B doc', async () => {
-  await assertFails(getDoc(doc(userA, 'budgetSettings/B')));
-});
-await test('budgetSettings: userA can write own doc', async () => {
-  await assertSucceeds(setDoc(doc(userA, 'budgetSettings/A'), { monthlyBudget: 1234 }));
-});
-await test('budgetSettings: userA canNOT write B doc', async () => {
-  await assertFails(setDoc(doc(userA, 'budgetSettings/B'), { monthlyBudget: 9 }));
-});
-await test('linkTokens: signed-in read DENIED (admin-only)', async () => {
-  await assertFails(getDoc(doc(userA, 'linkTokens/t1')));
-});
-await test('linkTokens: signed-in write DENIED (admin-only)', async () => {
-  await assertFails(setDoc(doc(userA, 'linkTokens/t2'), { lineId: 'A' }));
-});
-await test('userLinks: user can read own (uid match)', async () => {
-  await assertSucceeds(getDoc(doc(userA, 'userLinks/appuid-A')));
-});
-await test('userLinks: user canNOT read other uid', async () => {
-  await assertFails(getDoc(doc(userB, 'userLinks/appuid-A')));
-});
-// ---- グループ支出の書き込み緩和（Gmail 自動取込を web から扱えるようにする） ----
-await test('group expense: signed-in user can UPDATE (not owner)', async () => {
-  await assertSucceeds(updateDoc(doc(userA, 'expenses/expG'), { amount: 301 }));
-});
-await test('group expense: gmail-owned can be UPDATED by signed-in user', async () => {
-  await assertSucceeds(updateDoc(doc(userA, 'expenses/expGmail'), { amount: 401 }));
-});
-await test('group expense: UPDATE canNOT reassign owner', async () => {
-  await assertFails(updateDoc(doc(userA, 'expenses/expGmail'), { lineId: 'A' }));
-});
-await test('non-group expense of others still DENIED for update', async () => {
-  await assertFails(updateDoc(doc(userA, 'expenses/expB'), { amount: 999 }));
-});
-await test('group expense: gmail-owned can be DELETED by signed-in user', async () => {
-  await assertSucceeds(deleteDoc(doc(userA, 'expenses/expGmail')));
-});
-await test('group expense authored by a person canNOT be deleted by others', async () => {
-  await assertFails(deleteDoc(doc(userA, 'expenses/expG')));
-});
-await test('gmail expense OUTSIDE a group canNOT be deleted', async () => {
-  await assertFails(deleteDoc(doc(userA, 'expenses/expGmailSolo')));
-});
-await test('LINE user can read groups / groupMembers', async () => {
-  await assertSucceeds(getDoc(doc(userA, 'groups/G1')));
-  await assertSucceeds(getDoc(doc(userA, 'groupMembers/m1')));
-});
-await test('anonymous user canNOT READ group expense', async () => {
+await test('匿名はグループ支出を読めない', async () => {
   await assertFails(getDoc(doc(anon, 'expenses/expG')));
 });
-await test('anonymous user canNOT read groups', async () => {
-  await assertFails(getDoc(doc(anon, 'groups/G1')));
+await test('groupId を持たない支出はメンバーでも読めない（所有者限定になる）', async () => {
+  await assertFails(getDoc(doc(userA, 'expenses/expLegacy')));
 });
-await test('anonymous user canNOT read groupMembers', async () => {
-  await assertFails(getDoc(doc(anon, 'groupMembers/m1')));
+
+// --- 更新 -----------------------------------------------------------------
+await test('本人は自分の支出を更新できる', async () => {
+  await assertSucceeds(updateDoc(doc(userA, 'expenses/expA'), { amount: 111 }));
 });
-await test('anonymous user canNOT update group expense', async () => {
+await test('他人の個人支出は更新できない', async () => {
+  await assertFails(updateDoc(doc(userA, 'expenses/expB'), { amount: 999 }));
+});
+await test('所有権の付け替え（lineId 変更）はできない', async () => {
+  await assertFails(updateDoc(doc(userA, 'expenses/expA'), { lineId: 'B' }));
+});
+await test('メンバーは他人が登録したグループ支出を更新できる', async () => {
+  await assertSucceeds(updateDoc(doc(userA, 'expenses/expG'), { amount: 301 }));
+});
+await test('メンバーは Gmail 取込のグループ支出を更新できる', async () => {
+  await assertSucceeds(updateDoc(doc(userA, 'expenses/expGmail'), { amount: 401 }));
+});
+await test('グループ支出の更新でも所有権は付け替えられない', async () => {
+  await assertFails(updateDoc(doc(userA, 'expenses/expGmail'), { lineId: 'A' }));
+});
+await test('★ 非メンバーはグループ支出を更新できない', async () => {
+  await assertFails(updateDoc(doc(userC, 'expenses/expG'), { amount: 999 }));
+});
+await test('匿名はグループ支出を更新できない', async () => {
   await assertFails(updateDoc(doc(anon, 'expenses/expG'), { amount: 777 }));
 });
 
-await test('default-deny: unknown collection read DENIED', async () => {
+// --- 削除 -----------------------------------------------------------------
+await test('本人は自分の支出を削除できる', async () => {
+  await assertSucceeds(deleteDoc(doc(userA, 'expenses/expADel')));
+});
+await test('他人の個人支出は削除できない', async () => {
+  await assertFails(deleteDoc(doc(userA, 'expenses/expB')));
+});
+await test('メンバーは Gmail 取込のグループ支出を削除できる', async () => {
+  await assertSucceeds(deleteDoc(doc(userA, 'expenses/expGmailDel')));
+});
+await test('人が登録したグループ支出は他メンバーでも削除できない', async () => {
+  await assertFails(deleteDoc(doc(userA, 'expenses/expG')));
+});
+await test('グループ外の Gmail 支出は削除できない', async () => {
+  await assertFails(deleteDoc(doc(userA, 'expenses/expGmailSolo')));
+});
+await test('★ 非メンバーは Gmail 取込のグループ支出を削除できない', async () => {
+  await assertFails(deleteDoc(doc(userC, 'expenses/expGmail')));
+});
+
+// --- web が実際に投げるクエリ形 --------------------------------------------
+await test('クエリ: 自分の支出（where lineId==自分）', async () => {
+  await assertSucceeds(getDocs(query(collection(userA, 'expenses'), where('lineId', '==', 'A'))));
+});
+await test('クエリ: グループ支出（where groupId==G1）をメンバーが取得', async () => {
+  await assertSucceeds(getDocs(query(collection(userA, 'expenses'), where('groupId', '==', 'G1'))));
+});
+await test('★ クエリ: グループ支出を非メンバーが取得すると拒否', async () => {
+  await assertFails(getDocs(query(collection(userC, 'expenses'), where('groupId', '==', 'G1'))));
+});
+// list はクエリ制約からの証明が必要なため、ルールが見る groupId を制約しない
+// クエリ（lineGroupId 指定）は拒否される。web はこの形では引かない。
+await test('クエリ: lineGroupId 指定はメンバーでも拒否（ルールが groupId を見るため）', async () => {
+  await assertFails(getDocs(query(collection(userA, 'expenses'), where('lineGroupId', '==', 'L1'))));
+});
+await test('クエリ: 自分のメンバーシップ（where lineId==自分）', async () => {
+  await assertSucceeds(getDocs(query(collection(userA, 'groupMembers'), where('lineId', '==', 'A'))));
+});
+await test('クエリ: メンバー一覧（where groupId==G1）をメンバーが取得', async () => {
+  await assertSucceeds(getDocs(query(collection(userA, 'groupMembers'), where('groupId', '==', 'G1'))));
+});
+await test('★ クエリ: メンバー一覧を非メンバーが取得すると拒否', async () => {
+  await assertFails(getDocs(query(collection(userC, 'groupMembers'), where('groupId', '==', 'G1'))));
+});
+// groups の read はパスのワイルドカードで判定するため getDoc 専用。
+// list はドキュメントIDをクエリ制約から証明できないので必ず拒否される。
+await test('クエリ: groups の list はメンバーでも拒否（getDoc 専用の条件のため）', async () => {
+  await assertFails(getDocs(query(collection(userA, 'groups'), where('lineGroupId', '==', 'L1'))));
+});
+
+// --- groups / groupMembers ------------------------------------------------
+await test('メンバーは groups を読める', async () => {
+  await assertSucceeds(getDoc(doc(userA, 'groups/G1')));
+});
+await test('★ 非メンバーは groups（inviteCode を含む）を読めない', async () => {
+  await assertFails(getDoc(doc(userC, 'groups/G1')));
+});
+await test('匿名は groups を読めない', async () => {
+  await assertFails(getDoc(doc(anon, 'groups/G1')));
+});
+await test('メンバーは同じグループの他メンバーを読める', async () => {
+  await assertSucceeds(getDoc(doc(userA, 'groupMembers/G1_B')));
+});
+await test('★ 非メンバーは他人のメンバーシップを読めない', async () => {
+  await assertFails(getDoc(doc(userC, 'groupMembers/G1_A')));
+});
+await test('★ 権限昇格: 自分をグループに追加できない', async () => {
+  await assertFails(setDoc(doc(userC, 'groupMembers/G1_C'), { groupId: 'G1', lineId: 'C', isActive: true }));
+});
+await test('★ メンバーでもメンバーシップは書き換えられない（Admin SDK 専用）', async () => {
+  await assertFails(updateDoc(doc(userA, 'groupMembers/G1_A'), { displayName: 'X' }));
+});
+await test('★ groups はクライアントから作成できない', async () => {
+  await assertFails(setDoc(doc(userC, 'groups/G2'), { createdBy: 'C', inviteCode: 'X' }));
+});
+
+// --- 設定系 ---------------------------------------------------------------
+await test('設定: 自分のドキュメント（doc id == lineId）を読める', async () => {
+  await assertSucceeds(getDoc(doc(userA, 'budgetSettings/A')));
+});
+await test('設定: 他人のドキュメントは読めない', async () => {
+  await assertFails(getDoc(doc(userA, 'budgetSettings/B')));
+});
+await test('設定: 自分のドキュメントに書ける', async () => {
+  await assertSucceeds(setDoc(doc(userA, 'budgetSettings/A'), { monthlyBudget: 1234 }));
+});
+await test('設定: 他人のドキュメントには書けない', async () => {
+  await assertFails(setDoc(doc(userA, 'budgetSettings/B'), { monthlyBudget: 9 }));
+});
+
+// --- Admin SDK 専用コレクション --------------------------------------------
+await test('linkTokens はクライアントから読めない', async () => {
+  await assertFails(getDoc(doc(userA, 'linkTokens/t1')));
+});
+await test('linkTokens はクライアントから書けない', async () => {
+  await assertFails(setDoc(doc(userA, 'linkTokens/t2'), { lineId: 'A' }));
+});
+await test('userLinks: 本人の appUid のドキュメントは読める', async () => {
+  await assertSucceeds(getDoc(doc(userA, 'userLinks/appuid-A')));
+});
+await test('userLinks: 他人の appUid のドキュメントは読めない', async () => {
+  await assertFails(getDoc(doc(userB, 'userLinks/appuid-A')));
+});
+await test('★ userLinks: クライアントからは書けない（appUid 解決の汚染防止）', async () => {
+  await assertFails(setDoc(doc(userA, 'userLinks/appuid-A'), { lineIds: ['A', 'B'] }));
+});
+await test('default-deny: 未定義コレクションは読めない', async () => {
   await assertFails(getDoc(doc(userA, 'userCustomCategories/x')));
 });
 

--- a/web/app/expenses/page.tsx
+++ b/web/app/expenses/page.tsx
@@ -23,7 +23,7 @@ import {
   RefreshCw,
   ExternalLink,
 } from "lucide-react";
-import { useLineAuth, useExpenses, useGroupMembers, useLineGroupMembers } from "../../lib/hooks";
+import { useLineAuth, useExpenses, useGroupMembers } from "../../lib/hooks";
 import type { Expense } from "../../lib/hooks";
 import PreviewModeBanner from "../../components/PreviewModeBanner";
 import GuestGuide from "../../components/GuestGuide";
@@ -254,11 +254,10 @@ function ExpensesPageContent() {
   // Get group members for the expense being edited
   const editingExpenseData = editingExpense ? expenses.find(e => e.id === editingExpense) : null;
   const editingGroupId = editingExpenseData?.groupId || null;
-  const editingLineGroupId = editingExpenseData?.lineGroupId || null;
-  
-  // Try both group ID and LINE group ID based member fetching
+
+  // グループ支出には必ず groupId が付くため、lineGroupId 由来のフォールバックは廃止した。
+  // セキュリティルールがメンバーシップを groupId で判定するようになったこととも整合する。
   const { members: groupMembers, loading: membersLoading, error: membersError } = useGroupMembers(editingGroupId);
-  const { members: lineGroupMembers, loading: lineGroupMembersLoading } = useLineGroupMembers(editingLineGroupId);
   
   // Get all users who have ever created expenses (across all groups)
   // 入力者と支払い者の両方を含める
@@ -344,7 +343,7 @@ function ExpensesPageContent() {
   // Combine all available users: formal group members, group history users, and all historical users
   // 支出履歴のdisplayNameを優先（より正確な名前が入っている）
   const availableMembers = useMemo(() => {
-    const formalMembers = groupMembers.length > 0 ? groupMembers : lineGroupMembers;
+    const formalMembers = groupMembers;
     const combinedMap = new Map();
 
     // Priority 1: Add formal group members (メンバーシップ情報として追加)
@@ -399,7 +398,7 @@ function ExpensesPageContent() {
     });
 
     return Array.from(combinedMap.values());
-  }, [groupMembers, lineGroupMembers, groupExpenseUsers, allHistoricalUsers]);
+  }, [groupMembers, groupExpenseUsers, allHistoricalUsers]);
   
   // Debug logging - より詳細な情報を追加
   if (editingExpense) {
@@ -419,18 +418,15 @@ function ExpensesPageContent() {
     console.log("--- 編集中の支出データ ---");
     console.log("EditingExpenseData:", editingExpenseData);
     console.log("EditingGroupId:", editingGroupId);
-    console.log("EditingLineGroupId:", editingLineGroupId);
     
     console.log("--- ユーザー取得結果 ---");
     console.log("GroupMembers (正式メンバー):", groupMembers);
-    console.log("LineGroupMembers (LINEグループメンバー):", lineGroupMembers);
     console.log("GroupExpenseUsers (このグループの履歴):", groupExpenseUsers);
     console.log("AllHistoricalUsers (全履歴ユーザー):", allHistoricalUsers);
     console.log("AvailableMembers (最終的な選択肢):", availableMembers);
     
     console.log("--- ローディング状態 ---");
     console.log("MembersLoading:", membersLoading);
-    console.log("LineGroupMembersLoading:", lineGroupMembersLoading);
     console.log("MembersError:", membersError);
     
     // 選択肢の詳細を表示

--- a/web/lib/hooks.ts
+++ b/web/lib/hooks.ts
@@ -273,6 +273,36 @@ export function useLineAuth() {
   };
 }
 
+/**
+ * 自分が所属する（有効な）グループの groupId 一覧を取得する。
+ *
+ * 以前はユーザー自身の支出を最大200件走査して lineGroupId を集めていたが、
+ * (1) 支出を一度も登録していないメンバーはグループを検出できない
+ * (2) 200件を超えると取りこぼしうる
+ * (3) セキュリティルールがメンバーシップで判定するようになったため、
+ *     グループの所在は groupMembers を正とすべき
+ * という理由から、groupMembers から引く方式に変更した。
+ *
+ * このクエリ形（where lineId == 自分）はルールの「自分のメンバーシップは読める」
+ * 条項で許可される。
+ */
+async function fetchMyActiveGroupIds(lineId: string): Promise<string[]> {
+  if (!db) return [];
+  const snapshot = await getDocs(
+    query(
+      collection(db, 'groupMembers'),
+      where('lineId', '==', lineId),
+      where('isActive', '==', true)
+    )
+  );
+  const groupIds = new Set<string>();
+  snapshot.docs.forEach((d) => {
+    const groupId = (d.data() as { groupId?: string }).groupId;
+    if (groupId) groupIds.add(groupId);
+  });
+  return Array.from(groupIds);
+}
+
 export function useExpenses(userId: string | null, periodDays: number = 50, limitCount: number = 200, customStartDate?: string) {
   const expensesCacheKey = `expenses:${userId}:${periodDays}:${limitCount}:${customStartDate || ''}`;
   const [expenses, setExpenses] = useState<Expense[]>(() => getCached<Expense[]>(expensesCacheKey) ?? []);
@@ -397,41 +427,13 @@ export function useExpenses(userId: string | null, periodDays: number = 50, limi
         let lineGroupExpenses: Expense[] = [];
         
         try {
-          // First, get all user's expenses to find LINE group IDs they've participated in
-          console.log("=== ユーザーの全支出からLINEグループIDを検索 ===");
-          const allUserExpensesQuery = query(
-            collection(db, 'expenses'),
-            where('lineId', '==', userId),
-            limit(200) // Increase limit to get more data
-          );
+          // 所属グループは groupMembers を正として引く（支出の走査はしない）
+          const userGroupIds = await fetchMyActiveGroupIds(userId);
+          console.log("ユーザーが参加するグループID:", userGroupIds);
           
-          const allUserExpensesSnapshot = await getDocs(allUserExpensesQuery);
-          const userLineGroupIds = new Set<string>();
-          
-          console.log("ユーザーの全支出件数:", allUserExpensesSnapshot.docs.length);
-          
-          allUserExpensesSnapshot.docs.forEach(doc => {
-            const data = doc.data();
-            console.log("支出データ:", {
-              id: doc.id,
-              amount: data.amount,
-              description: data.description,
-              lineGroupId: data.lineGroupId,
-              date: data.date
-            });
-            
-            if (data.lineGroupId) {
-              userLineGroupIds.add(data.lineGroupId);
-              console.log("LINEグループID発見:", data.lineGroupId);
-            }
-          });
-          
-          console.log("ユーザーが参加するLINEグループID:", Array.from(userLineGroupIds));
-          console.log("検出されたLINEグループ数:", userLineGroupIds.size);
-          
-          // Get expenses from each LINE group
-          for (const lineGroupId of userLineGroupIds) {
-            console.log("=== LINEグループ", lineGroupId, "の支出を取得中... ===");
+          // Get expenses from each group
+          for (const groupId of userGroupIds) {
+            console.log("=== グループ", groupId, "の支出を取得中... ===");
             
             let lineGroupQuery;
             let startDate, endDate;
@@ -442,7 +444,7 @@ export function useExpenses(userId: string | null, periodDays: number = 50, limi
               console.log("カスタム期間:", startDate, "〜", endDate);
               lineGroupQuery = query(
                 collection(db, 'expenses'),
-                where('lineGroupId', '==', lineGroupId),
+                where('groupId', '==', groupId),
                 where('date', '>=', startDate),
                 where('date', '<=', endDate),
                 limit(Math.max(limitCount, 500)) // Ensure we get enough data
@@ -453,7 +455,7 @@ export function useExpenses(userId: string | null, periodDays: number = 50, limi
               console.log("期間指定:", periodDays, "日間 (", startDate, "〜", endDate, ")");
               lineGroupQuery = query(
                 collection(db, 'expenses'),
-                where('lineGroupId', '==', lineGroupId),
+                where('groupId', '==', groupId),
                 where('date', '>=', startDate),
                 where('date', '<=', endDate),
                 limit(Math.max(limitCount, 500)) // Ensure we get enough data
@@ -462,7 +464,7 @@ export function useExpenses(userId: string | null, periodDays: number = 50, limi
               console.log("全期間での取得");
               lineGroupQuery = query(
                 collection(db, 'expenses'),
-                where('lineGroupId', '==', lineGroupId),
+                where('groupId', '==', groupId),
                 limit(Math.max(limitCount, 500)) // Ensure we get enough data
               );
             }
@@ -492,7 +494,7 @@ export function useExpenses(userId: string | null, periodDays: number = 50, limi
               });
             });
             
-            console.log("LINEグループ", lineGroupId, "の支出:", lineGroupExpenseList.length, "件");
+            console.log("グループ", groupId, "の支出:", lineGroupExpenseList.length, "件");
             lineGroupExpenses = [...lineGroupExpenses, ...lineGroupExpenseList];
           }
           
@@ -715,28 +717,14 @@ export function useMonthlyStats(userId: string | null, year: number, month: numb
         let lineGroupExpenses: Expense[] = [];
         
         try {
-          // Get all user's expenses to find LINE group IDs they've participated in
-          const allUserExpensesQuery = query(
-            collection(db, 'expenses'),
-            where('lineId', '==', userId),
-            limit(100)
-          );
-          
-          const allUserExpensesSnapshot = await getDocs(allUserExpensesQuery);
-          const userLineGroupIds = new Set<string>();
-          
-          allUserExpensesSnapshot.docs.forEach(doc => {
-            const data = doc.data();
-            if (data.lineGroupId) {
-              userLineGroupIds.add(data.lineGroupId);
-            }
-          });
-          
-          // Get expenses from LINE groups for the specified period
-          for (const lineGroupId of userLineGroupIds) {
+          // 所属グループは groupMembers を正として引く（支出の走査はしない）
+          const userGroupIds = await fetchMyActiveGroupIds(userId);
+
+          // Get expenses from groups for the specified period
+          for (const groupId of userGroupIds) {
             const lineGroupQuery = query(
               collection(db, 'expenses'),
-              where('lineGroupId', '==', lineGroupId),
+              where('groupId', '==', groupId),
               where('date', '>=', startDate),
               where('date', '<=', endDate)
             );
@@ -750,7 +738,7 @@ export function useMonthlyStats(userId: string | null, year: number, month: numb
             lineGroupExpenses = [...lineGroupExpenses, ...lineGroupExpenseList];
           }
           
-          console.log("月次統計 - LINEグループの支出:", lineGroupExpenses.length, "件");
+          console.log("月次統計 - グループの支出:", lineGroupExpenses.length, "件");
         } catch (groupError) {
           console.error("月次統計 - LINEグループ支出取得エラー:", groupError);
         }
@@ -965,81 +953,6 @@ export function useGroupExpenses(groupId: string | null, limitCount: number = 50
   return { expenses, loading, error };
 }
 
-export function useLineGroupExpenses(lineGroupId: string | null, limitCount: number = 50) {
-  const [expenses, setExpenses] = useState<Expense[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!lineGroupId) {
-      setLoading(false);
-      return;
-    }
-
-    const fetchLineGroupExpenses = async () => {
-      // Firebase初期化を待機
-      const isConnected = await waitForFirebase();
-      if (!isConnected) {
-        const status = getFirebaseStatus();
-        setError(`Firebase接続エラー: ${status.error?.message || '初期化に失敗しました'}`);
-        setLoading(false);
-        return;
-      }
-      try {
-        setLoading(true);
-        setError(null);
-        
-        if (!db) {
-          throw new Error('Firestoreデータベースが利用できません');
-        }
-        
-        console.log("LINEグループ支出取得開始 - lineGroupId:", lineGroupId);
-        
-        const q = query(
-          collection(db, 'expenses'),
-          where('lineGroupId', '==', lineGroupId),
-          limit(limitCount)
-        );
-        
-        const querySnapshot = await getDocs(q);
-        console.log("LINEグループ支出クエリ結果:", querySnapshot.docs.length, "件");
-        
-        const expenseList = querySnapshot.docs.map(doc => ({
-          id: doc.id,
-          ...doc.data()
-        } as Expense));
-        
-        console.log("取得したLINEグループ支出:", expenseList);
-        
-        // Sort in memory by creation time desc
-        const sortedExpenses = expenseList.sort((a, b) => {
-          const aTime = a.createdAt ? 
-            (typeof a.createdAt === 'object' && 'seconds' in a.createdAt ? 
-              a.createdAt.seconds * 1000 : 
-              (a.createdAt as Date).getTime()) : 0;
-          const bTime = b.createdAt ? 
-            (typeof b.createdAt === 'object' && 'seconds' in b.createdAt ? 
-              b.createdAt.seconds * 1000 : 
-              (b.createdAt as Date).getTime()) : 0;
-          return bTime - aTime; // desc order
-        });
-        
-        setExpenses(sortedExpenses);
-        setError(null);
-      } catch (err) {
-        const errorMessage = handleFirestoreError(err);
-        console.error('Error fetching LINE group expenses:', err);
-        setError(errorMessage);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchLineGroupExpenses();
-  }, [lineGroupId, limitCount]);
-
-  return { expenses, loading, error };
-}
 
 // グループメンバーを取得するフック
 export function useGroupMembers(groupId: string | null) {
@@ -1120,105 +1033,6 @@ export function useGroupMembers(groupId: string | null) {
   return { members, loading, error };
 }
 
-// LINE Group IDベースでメンバーを取得するフック（フォールバック用）
-export function useLineGroupMembers(lineGroupId: string | null) {
-  const [members, setMembers] = useState<GroupMember[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!lineGroupId) {
-      setLoading(false);
-      setMembers([]);
-      return;
-    }
-
-    const fetchLineGroupMembers = async () => {
-      // Firebase初期化を待機
-      const isConnected = await waitForFirebase();
-      if (!isConnected) {
-        const status = getFirebaseStatus();
-        setError(`Firebase接続エラー: ${status.error?.message || '初期化に失敗しました'}`);
-        setLoading(false);
-        return;
-      }
-      try {
-        setLoading(true);
-        console.log("LINE グループメンバー取得開始 - lineGroupId:", lineGroupId);
-
-        // まずlineGroupIdに対応するグループを探す
-        const groupQuery = query(
-          collection(db!, 'groups'),
-          where('lineGroupId', '==', lineGroupId)
-        );
-
-        const groupSnapshot = await getDocs(groupQuery);
-        
-        if (groupSnapshot.empty) {
-          console.log("LINE Group IDに対応するグループが見つかりません");
-          setMembers([]);
-          setError(null);
-          return;
-        }
-
-        const group = groupSnapshot.docs[0];
-        const groupId = group.id;
-        
-        console.log("対応するgroupId:", groupId);
-
-        // そのグループのメンバーを取得
-        const membersQuery = query(
-          collection(db!, 'groupMembers'),
-          where('groupId', '==', groupId),
-          where('isActive', '==', true)
-        );
-
-        const membersSnapshot = await getDocs(membersQuery);
-        
-        if (membersSnapshot.empty) {
-          console.log("グループメンバーが見つかりません");
-          setMembers([]);
-          setError(null);
-          return;
-        }
-
-        const memberList: GroupMember[] = membersSnapshot.docs.map(doc => {
-          const data = doc.data();
-          console.log("--- LINE GroupMember生データ ---");
-          console.log("Document ID:", doc.id);
-          console.log("Raw data:", data);
-          console.log("displayName:", data.displayName, typeof data.displayName);
-          console.log("lineId:", data.lineId);
-          console.log("groupId:", data.groupId);
-          console.log("isActive:", data.isActive);
-          
-          return {
-            id: doc.id,
-            groupId: data.groupId,
-            lineId: data.lineId,
-            displayName: data.displayName || `LineUnknown_${data.lineId?.slice(-6) || 'NoID'}`,
-            joinedAt: data.joinedAt,
-            isActive: data.isActive
-          } as GroupMember;
-        });
-
-        console.log("処理後のLINE グループメンバー:", memberList);
-        setMembers(memberList);
-        setError(null);
-      } catch (err) {
-        const errorMessage = handleFirestoreError(err);
-        console.error('Error fetching LINE group members:', err);
-        setError(errorMessage);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchLineGroupMembers();
-  }, [lineGroupId]);
-
-  return { members, loading, error };
-}
 
 // 予算設定インターフェース
 export interface BudgetConfig {


### PR DESCRIPTION
## 🎯 目的

#157 / #162 に「既知の限界」として残していた、**LINE 本人確認済みなら誰でも任意のグループ支出を読める**状態を解消する。

#163（Phase 1）で `groupMembers` を決定的ID（`${groupId}_${lineId}`）へ移行済み。移行スクリプトの検証3項目が本番でパスしていることを前提とする。

```
[1] 決定的IDでないドキュメント: 0 件 ✓
[2] 重複メンバー: 0 件 ✓
[3] グループ支出を持つ LINE ユーザー: 2 名 / 有効なメンバー登録なし: 0 名 ✓

判定: ✓ Phase 2（ルール厳格化）へ進めます
```

## 🔑 実装の前提となった発見: Firestore の `list` は1件ずつ評価しない

実装中にルールユニットテストが2件失敗し、原因を最小の実験で切り分けたところ、**`list`（クエリ）は `get` と評価方法が根本的に違う**ことが判明した。ドキュメントを1件ずつ評価するのではなく、**「クエリの制約からルールを満たすと証明できるか」**で判定される。

| ルールが参照 | クエリの制約 | 結果 |
|---|---|---|
| `owner` | `where('owner','==','A')` | ✅ 許可 |
| `owner` | `where('tag','==','x')` | ❌ 拒否 |
| `exists(marks/$(gid))` | `where('gid','==','G1')` | ✅ 許可 |
| `exists(marks/$(gid))` | `where('tag','==','x')` | ❌ 拒否 |
| パスのワイルドカード `{docId}` | 任意 | ❌ 拒否（`Null value error`） |

つまり **ルールを `groupId` で判定するなら、web も `groupId` で引かなければならない**。これが web 側の変更が必要になった理由。

## 📋 ルールの変更

### メンバー判定

```
function isMemberOf(groupId) {
  return isLineUser()
         && groupId != null
         && exists(/databases/$(database)/documents/groupMembers/$(groupId + '_' + myLineId()))
         && get(/databases/$(database)/documents/groupMembers/$(groupId + '_' + myLineId())).data.get('isActive', false) == true;
}
```

`exists()` と `get()` は同一パスならキャッシュされ、1評価あたり10回というドキュメントアクセス上限にも1回としてしか数えられない。数百件を返すクエリでも参照先は1文書に収まる。

| コレクション | 変更前 | 変更後 |
|---|---|---|
| `expenses` read/update/delete（グループ条項） | LINE ユーザーなら誰でも | **そのグループの有効なメンバーのみ** |
| `groups` read | LINE ユーザーなら誰でも | **メンバーのみ**（`inviteCode` を含むため） |
| `groups` write | `createdBy` が自分なら作成可 | **全面禁止**（Admin SDK のみ） |
| `groupMembers` read | LINE ユーザーなら誰でも | **自分の行 or 同じグループのメンバー** |
| `groupMembers` write | 自分の lineId なら作成可 | **全面禁止**（Admin SDK のみ） |
| `userLinks` write | 本人の uid なら可 | **全面禁止**（Admin SDK のみ） |

**`groupMembers` の write 禁止は必須の対応。** メンバーシップが権限判定の根拠になったため、自己登録を許すと「任意グループのメンバー文書を自分で作る → その世帯の家計簿を読む」という権限昇格が成立する。web は `groupMembers` に書き込まないことを確認済み。

**`userLinks` の write 禁止**は、bot が `lineId` から `appUid` を `array-contains` で引くため、クライアントが任意の `lineIds` を持つ文書を作れると他人の appUid 解決を汚染できたことへの対応。

あわせて、欠損フィールドで評価エラーにならないようフィールド参照を `get(key, default)` に統一した。

## 📋 web の変更

- **`useExpenses` / `useMonthlyStats`**: グループ支出の取得を `where('lineGroupId','==',…)` → `where('groupId','==',…)` に変更。
- **所属グループの判定方法を変更**: 「自分の支出を最大200件走査して `lineGroupId` を集める」→ `groupMembers` 由来（`fetchMyActiveGroupIds`）。副産物として次の既存問題も解消する。
  - 支出を一度も登録していないメンバーがグループを検出できなかった
  - 支出が200件を超えると取りこぼしうる
  - 走査のための追加クエリが不要になる
- **expenses ページ**: `lineGroupId` 由来のメンバー取得フォールバックを削除（グループ支出には必ず `groupId` が付くため不要）。
- **未使用フックの削除**: `useLineGroupExpenses` / `useLineGroupMembers`。どちらも `lineGroupId` で引くため新ルール下では機能せず、放置すると将来の罠になる。

## 🧪 テスト

**エミュレータでルールユニットテスト 52 ケース pass**（従来 35 → 52）。

```
52 passed, 0 failed
```

主な追加ケース:

| ケース | 期待 |
|---|---|
| 非メンバーの LINE ユーザーがグループ支出を read / update / delete | 拒否 |
| 脱退済み（`isActive:false`）メンバーがグループ支出を read | 拒否 |
| 非メンバーが `groups`（`inviteCode` 含む）を read | 拒否 |
| 非メンバーが他人のメンバーシップを read | 拒否 |
| **権限昇格: 自分をグループに追加** | **拒否** |
| メンバーでもメンバーシップを書き換え | 拒否 |
| `userLinks` へのクライアント書き込み | 拒否 |
| `groupId` を持たない支出をメンバーが read | 拒否（所有者限定になる） |
| web の実クエリ形（`where groupId==G1` / `where lineId==自分`） | 許可 |
| `where lineGroupId==L1`（ルールが証明できない形） | 拒否 |

- [x] `npx tsc --noEmit`（web）エラー 0
- [x] `npm -w web run lint` エラー 0（警告 23 → 21 に減少。新規追加なし）
- [x] `npm -w web run build` 成功
- [x] `npm -w bot run build` / `npm -w bot test` 成功

## ⚠️ マージ後の確認事項

ルールと web を同時に変えるため、デプロイ後に実機で以下を確認したい。

1. グループ家計簿（459件の共有支出）が従来どおり表示されること
2. 月次サマリー・グラフの数値が変わらないこと
3. Gmail 由来の支出の編集・削除が引き続きできること
4. 支出編集時のメンバー選択リストが正しく出ること

## 📌 残る限界

`groupId` を持たない支出（`lineGroupId` のみ）はメンバーでも読めず、所有者限定になる。本番データには0件だが、メンバー未登録の利用者が LINE グループで支出を登録すると生まれうる（bot の `activeGroup` が `groupMembers` 由来のため）。招待コードでの参加を経てメンバーになることが前提となる。

`bot/src/firestore.ts` の `getOrCreateGroupForLineGroup` は定義のみで未使用（デッドコード）。これを配線すれば「LINE グループで発言したら自動的にメンバーになる」挙動にできるが、信頼モデルの変更を伴うため本PRの対象外とした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GcXZLvy359vkTHoQUDbx2
